### PR TITLE
ci: add release-plz config + workflow

### DIFF
--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -1,0 +1,58 @@
+name: release-plz
+
+on:
+  push:
+    branches: [main]
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  # Publish the crates and cut the tag + GitHub Release once the
+  # release PR is merged. The Release fires `release: published`,
+  # which the packaging workflows (Flatpak, AUR) build on.
+  release:
+    name: release-plz release
+    runs-on: ubuntu-latest
+    container:
+      image: ghcr.io/gtk-rs/gtk4-rs/gtk4:latest
+    steps:
+      - name: Install native deps
+        run: yum install -y gtk4-devel libadwaita-devel gtk4-layer-shell-devel wayland-devel
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+      - uses: release-plz/action@v0.5
+        with:
+          command: release
+        env:
+          GITHUB_TOKEN: ${{ secrets.RELEASE_PLZ_TOKEN }}
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+
+  # Keep the release PR (version bump + CHANGELOG) up to date on
+  # every push to main.
+  release-pr:
+    name: release-plz PR
+    runs-on: ubuntu-latest
+    container:
+      image: ghcr.io/gtk-rs/gtk4-rs/gtk4:latest
+    concurrency:
+      group: release-plz-pr
+      cancel-in-progress: false
+    steps:
+      - name: Install native deps
+        run: yum install -y gtk4-devel libadwaita-devel gtk4-layer-shell-devel wayland-devel
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+      - uses: release-plz/action@v0.5
+        with:
+          command: release-pr
+        env:
+          GITHUB_TOKEN: ${{ secrets.RELEASE_PLZ_TOKEN }}
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}

--- a/release-plz.toml
+++ b/release-plz.toml
@@ -1,0 +1,24 @@
+# release-plz — automated crates.io releases. https://release-plz.dev
+#
+# release-plz opens a "release PR" that bumps the workspace version and
+# updates CHANGELOG.md. Merging that PR publishes every crate to
+# crates.io in dependency order, then cuts one git tag + one GitHub
+# Release for the app. That Release fires `release: published`, which
+# the packaging workflows (Flatpak, AUR) build on.
+
+[workspace]
+# Release only when the release PR is merged — not on every push.
+release_always = false
+# Libraries publish to crates.io but get no tag, Release, or changelog
+# of their own; the app crate below owns all three.
+git_tag_enable = false
+git_release_enable = false
+changelog_update = false
+
+[[package]]
+name = "tensaku"
+git_tag_enable = true
+git_tag_name = "v{{ version }}"
+git_release_enable = true
+git_release_name = "v{{ version }}"
+changelog_update = true


### PR DESCRIPTION
## What

First step of migrating tensaku to the release-plz pipeline proven on mousehop.

- **`release-plz.toml`** — unified workspace config. Both `tensaku` and `tensaku_cli` publish to crates.io, but only the root `tensaku` crate owns the tag/Release/changelog (so each release is one `vX.Y.Z` tag + one GitHub Release, which fires `release: published`).
- **`.github/workflows/release-plz.yml`** — `release-pr` + `release` jobs. Runs in the same `ghcr.io/gtk-rs/gtk4-rs/gtk4:latest` container the existing `lint.yml` uses; same yum-installed deps.

## What this PR doesn't do

- `release.sh` and `RELEASING.md` are untouched. Subsequent PRs:
  - PR 2: add Linux tarball CI job + AUR publish workflow.
  - PR 3: `perf(ci)` caches.
  - PR 4: retire `release.sh`, rewrite `RELEASING.md`.

## Secrets

Already present on the repo (verified): `RELEASE_PLZ_TOKEN`, `CARGO_REGISTRY_TOKEN`, `AUR_SSH_KEY`.

## Once merged

release-plz runs on every push to main. With no `feat:`/`fix:` since the last published version (0.25.0), no release PR will open yet — it'll appear when the next real change lands. Same dynamic as mousehop's first run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)