### PR TITLE
ci: add Linux tarball CI job + AUR publish workflow

### DIFF
--- a/.github/workflows/aur-publish.yml
+++ b/.github/workflows/aur-publish.yml
@@ -1,0 +1,72 @@
+name: AUR publish
+
+# Pushes the updated package to the AUR after release-plz cuts a
+# Release. packaging/aur/PKGBUILD is the source of truth; this workflow
+# pins it to the release version, refreshes the checksums, regenerates
+# .SRCINFO, and pushes — creating the AUR package on the first run.
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Release tag to publish to the AUR (e.g. v0.26.0)'
+        required: true
+
+jobs:
+  aur:
+    name: Publish to the AUR
+    runs-on: ubuntu-latest
+    container: archlinux:base-devel
+    env:
+      AUR_PKG: tensaku
+      GH_REPO: jondkinney/tensaku
+      TAG: ${{ github.event.release.tag_name || inputs.tag }}
+    steps:
+      - name: Install tooling
+        run: pacman -Syu --noconfirm --needed git openssh pacman-contrib curl
+
+      - name: Publish to the AUR
+        env:
+          AUR_SSH_KEY: ${{ secrets.AUR_SSH_KEY }}
+        run: |
+          set -euo pipefail
+          ver="${TAG#v}"
+
+          # SSH access to the AUR. Pass options inline via
+          # GIT_SSH_COMMAND so we don't depend on ~/.ssh/config being
+          # honored — accept-new writes the AUR's host key to
+          # known_hosts on first connect (TOFU).
+          install -dm700 /root/.ssh
+          echo "$AUR_SSH_KEY" > /root/.ssh/id_aur
+          chmod 600 /root/.ssh/id_aur
+          touch /root/.ssh/known_hosts
+          export GIT_SSH_COMMAND='ssh -i /root/.ssh/id_aur -o IdentitiesOnly=yes -o StrictHostKeyChecking=accept-new -o UserKnownHostsFile=/root/.ssh/known_hosts'
+
+          # Grab packaging/aur/PKGBUILD at the released tag.
+          git clone --depth 1 --branch "$TAG" "https://github.com/$GH_REPO.git" app
+
+          # Clone the AUR repo; init a fresh one if the package is new.
+          if ! git clone "ssh://aur@aur.archlinux.org/${AUR_PKG}.git" aur; then
+            mkdir -p aur
+            git -C aur init -q -b master
+            git -C aur remote add origin "ssh://aur@aur.archlinux.org/${AUR_PKG}.git"
+          fi
+
+          # Drop in the PKGBUILD, pinned to this release.
+          cp app/packaging/aur/PKGBUILD aur/PKGBUILD
+          sed -i "s/^pkgver=.*/pkgver=$ver/;s/^pkgrel=.*/pkgrel=1/" aur/PKGBUILD
+
+          # makepkg / updpkgsums refuse to run as root.
+          useradd -m builder
+          chown -R builder:builder aur
+          sudo -H -u builder bash -c 'cd aur && updpkgsums && makepkg --printsrcinfo > .SRCINFO'
+
+          # Commit + push.
+          git config --global --add safe.directory "$PWD/aur"
+          cd aur
+          git config user.name 'tensaku release'
+          git config user.email 'release@users.noreply.github.com'
+          git add PKGBUILD .SRCINFO
+          git diff --cached --quiet || git commit -m "Update to $ver"
+          git push --quiet -u origin master

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,13 +1,42 @@
 name: release
 
-# Fires when release.sh publishes a GitHub Release. release.sh bundles
-# and attaches the x86_64 Linux tarball itself; this workflow adds the
-# Flatpak bundle as an extra asset on the same release.
+# Fires when release-plz creates a GitHub Release. Builds and attaches
+# the x86_64 Linux tarball and the Flatpak bundle as release assets.
 on:
   release:
     types: [published]
 
 jobs:
+  linux-tarball:
+    name: "Linux x86_64 tarball"
+    runs-on: ubuntu-latest
+    container:
+      image: ghcr.io/gtk-rs/gtk4-rs/gtk4:latest
+    permissions:
+      contents: write
+    steps:
+      - name: Install native deps + make
+        run: yum install -y gtk4-devel libadwaita-devel gtk4-layer-shell-devel wayland-devel make tar gzip
+
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Configure git safe directory
+        run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
+
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+
+      - name: Build tarball
+        run: make package
+
+      - name: Attach tarball to the release
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: ${{ github.event.release.tag_name }}
+          files: tensaku-${{ github.ref_name }}-x86_64.tar.gz
+
   flatpak:
     runs-on: ubuntu-latest
     container:

--- a/packaging/aur/PKGBUILD
+++ b/packaging/aur/PKGBUILD
@@ -1,0 +1,44 @@
+# Maintainer: Jon Kinney
+#
+# Source of truth for the AUR `tensaku` package. The aur-publish.yml
+# workflow copies this file, pins pkgver/pkgrel to the release,
+# refreshes sha256sums with updpkgsums, regenerates .SRCINFO, and
+# pushes to the AUR. Edit depends / package() etc. here — never in the
+# AUR repo directly.
+pkgname=tensaku
+pkgver=0.25.0
+pkgrel=1
+pkgdesc='Modern screenshot annotation tool for Wayland'
+arch=('x86_64')
+url='https://github.com/jondkinney/tensaku'
+license=('MPL-2.0')
+depends=('gtk4' 'gtk4-layer-shell' 'libadwaita' 'libepoxy' 'fontconfig')
+makedepends=('rust')
+source=("$pkgname-$pkgver.tar.gz::$url/archive/refs/tags/v$pkgver.tar.gz")
+sha256sums=('52762f03a109afa1749e941d2ce2ba9e1956e4fd1975347c0cd92ddfb6e35968')
+
+prepare() {
+  cd "$pkgname-$pkgver"
+  export RUSTUP_TOOLCHAIN=stable
+  cargo fetch --locked --target "$(rustc -vV | sed -n 's/host: //p')"
+}
+
+build() {
+  cd "$pkgname-$pkgver"
+  export RUSTUP_TOOLCHAIN=stable
+  export CARGO_TARGET_DIR=target
+  cargo build --frozen --release --features ci-release
+}
+
+package() {
+  cd "$pkgname-$pkgver"
+  install -Dm755 target/release/tensaku "$pkgdir/usr/bin/tensaku"
+  install -Dm644 dev.tensaku.Tensaku.desktop "$pkgdir/usr/share/applications/dev.tensaku.Tensaku.desktop"
+  install -Dm644 assets/tensaku.svg "$pkgdir/usr/share/icons/hicolor/scalable/apps/dev.tensaku.Tensaku.svg"
+  install -Dm644 man/tensaku.1 "$pkgdir/usr/share/man/man1/tensaku.1"
+  install -Dm644 completions/tensaku.bash "$pkgdir/usr/share/bash-completion/completions/tensaku"
+  install -Dm644 completions/tensaku.fish "$pkgdir/usr/share/fish/vendor_completions.d/tensaku.fish"
+  install -Dm644 completions/_tensaku "$pkgdir/usr/share/zsh/site-functions/_tensaku"
+  install -Dm644 LICENSE "$pkgdir/usr/share/licenses/$pkgname/LICENSE"
+  install -Dm644 NOTICE "$pkgdir/usr/share/licenses/$pkgname/NOTICE"
+}


### PR DESCRIPTION
## What

Step 2 of the release-plz migration (#1 added the release-plz config + workflow).

- **`linux-tarball` job in `release.yml`** — runs `make package` in the gtk-rs Fedora container (same image as `lint.yml`'s lint/doc jobs), then attaches `tensaku-vX.Y.Z-x86_64.tar.gz` to the GitHub Release. Existing flatpak job left alone.
- **`packaging/aur/PKGBUILD`** — source of truth for the AUR `tensaku` package. Copied verbatim from the existing `~/Code/aur/tensaku/PKGBUILD`. The CI workflow rewrites `pkgver` / `pkgrel` / `sha256sums` per release.
- **`.github/workflows/aur-publish.yml`** — same shape as mousehop's: Arch container, ssh options inlined via `GIT_SSH_COMMAND` with `StrictHostKeyChecking=accept-new`, `updpkgsums` + `makepkg --printsrcinfo`, push. Creates the AUR package on first run.

## What this PR doesn't do

- `release.sh` is still in place; subsequent PRs:
  - PR 3: `perf(ci)` cache (`Swatinem/rust-cache@v2`).
  - PR 4: retire `release.sh`, rewrite `RELEASING.md`.

## Once merged + the first release through release-plz cuts

- crates.io: `tensaku` + `tensaku_cli` republished.
- v0.X.Y tag + GitHub Release created.
- `tensaku-vX.Y.Z-x86_64.tar.gz` attached.
- `tensaku-vX.Y.Z.flatpak` attached (existing path).
- `aur.archlinux.org/packages/tensaku` updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)