### PR TITLE
fix(ci): install gh in release-plz container

### DIFF
--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -18,8 +18,11 @@ jobs:
     container:
       image: ghcr.io/gtk-rs/gtk4-rs/gtk4:latest
     steps:
-      - name: Install native deps
-        run: yum install -y gtk4-devel libadwaita-devel gtk4-layer-shell-devel wayland-devel
+      - name: Install native deps + gh CLI
+        # gh is needed by release-plz/action to look up the GitHub
+        # viewer's name/email for git authoring; the gtk-rs container
+        # doesn't ship it.
+        run: yum install -y gtk4-devel libadwaita-devel gtk4-layer-shell-devel wayland-devel gh
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
@@ -43,8 +46,11 @@ jobs:
       group: release-plz-pr
       cancel-in-progress: false
     steps:
-      - name: Install native deps
-        run: yum install -y gtk4-devel libadwaita-devel gtk4-layer-shell-devel wayland-devel
+      - name: Install native deps + gh CLI
+        # gh is needed by release-plz/action to look up the GitHub
+        # viewer's name/email for git authoring; the gtk-rs container
+        # doesn't ship it.
+        run: yum install -y gtk4-devel libadwaita-devel gtk4-layer-shell-devel wayland-devel gh
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0


### PR DESCRIPTION
## Issue

Every release-plz run since the merge has failed with:

```
/__w/_temp/.../sh: line 12: gh: command not found
##[error]Process completed with exit code 127.
```

`release-plz/action` has a small bash step that calls `gh api graphql ...` to look up the viewer's name + email for git author config. The `ghcr.io/gtk-rs/gtk4-rs/gtk4:latest` container that `lint.yml` uses (and that I borrowed) doesn't ship `gh`. (mousehop runs on a stock `ubuntu` runner where `gh` is pre-installed, so it didn't hit this.)

## Fix

Add `gh` to the yum install line in both jobs. One-word change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)