### PR TITLE
fix(ci): mark workspace as safe.directory for release-plz container

### DIFF
--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -26,6 +26,11 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
+      - name: Configure git safe directory
+        # Containerized job: workspace is owned by a different uid
+        # than the in-container root, so git refuses to operate on it
+        # without this exception.
+        run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
       - uses: release-plz/action@v0.5
@@ -54,6 +59,11 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
+      - name: Configure git safe directory
+        # Containerized job: workspace is owned by a different uid
+        # than the in-container root, so git refuses to operate on it
+        # without this exception.
+        run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
       - uses: release-plz/action@v0.5


### PR DESCRIPTION
## Issue

With `gh` now installed (PR #4), the next release-plz run got further but hit:

```
fatal: detected dubious ownership in repository at '/__w/tensaku/tensaku'
To add an exception for this directory, call:
    git config --global --add safe.directory /__w/tensaku/tensaku
```

Standard containerized-action issue — `actions/checkout` lays the workspace down as one uid, the container runs as another, and modern git refuses to operate on a repo it doesn't own.

## Fix

Add a `git config --global --add safe.directory "$GITHUB_WORKSPACE"` step right after checkout in both `release` and `release-pr` jobs. The existing flatpak job in `release.yml` already does this; mirror the pattern.

🤖 Generated with [Claude Code](https://claude.com/claude-code)