### PR TITLE
chore(ci): aggregate sibling crate commits into root CHANGELOG

### DIFF
--- a/release-plz.toml
+++ b/release-plz.toml
@@ -22,3 +22,6 @@ git_tag_name = "v{{ version }}"
 git_release_enable = true
 git_release_name = "v{{ version }}"
 changelog_update = true
+# Aggregate every workspace crate's commits into this crate's
+# CHANGELOG so a fix touching only a sibling still shows up here.
+changelog_include = ["tensaku_cli"]


### PR DESCRIPTION
## Issue

release-plz attributes commits per-package by source path. The current `release-plz.toml` sets `changelog_update = true` only on the root `tensaku` package, so a `fix:` touching only `tensaku_cli` (or any non-root crate) produces an empty `[X.Y.Z]` changelog entry.

## Fix

Add `changelog_include = ["tensaku_cli"]` to the `[[package]]` block. release-plz then pulls commits affecting `tensaku_cli`'s paths into `tensaku`'s changelog, so the single root `CHANGELOG.md` captures everything regardless of which crate the change lives in.

🤖 Generated with [Claude Code](https://claude.com/claude-code)