### PR TITLE
ci: add tensaku-bin and tensaku-git AUR variants

### DIFF
--- a/.github/workflows/aur-publish.yml
+++ b/.github/workflows/aur-publish.yml
@@ -1,9 +1,14 @@
 name: AUR publish
 
-# Pushes the updated package to the AUR after release-plz cuts a
-# Release. packaging/aur/PKGBUILD is the source of truth; this workflow
-# pins it to the release version, refreshes the checksums, regenerates
-# .SRCINFO, and pushes — creating the AUR package on the first run.
+# Publishes all three AUR variants after release-plz cuts a Release:
+#   - tensaku      (source build from the GitHub source tarball)
+#   - tensaku-bin  (prebuilt binary from the linux-tarball asset)
+#   - tensaku-git  (tracks main; pkgver() generated at build time)
+#
+# packaging/{aur,aur-bin,aur-git}/PKGBUILD are the source of truth.
+# This workflow pins per-release fields (pkgver, pkgrel, sha256sums),
+# regenerates .SRCINFO, and pushes to the matching AUR repo.
+
 on:
   release:
     types: [published]
@@ -15,11 +20,26 @@ on:
 
 jobs:
   aur:
-    name: Publish to the AUR
+    name: Publish ${{ matrix.aur_pkg }} to the AUR
     runs-on: ubuntu-latest
     container: archlinux:base-devel
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - aur_pkg: tensaku
+            pkgbuild_dir: aur
+            kind: source
+          - aur_pkg: tensaku-bin
+            pkgbuild_dir: aur-bin
+            kind: bin
+          - aur_pkg: tensaku-git
+            pkgbuild_dir: aur-git
+            kind: git
     env:
-      AUR_PKG: tensaku
+      AUR_PKG: ${{ matrix.aur_pkg }}
+      PKGBUILD_DIR: ${{ matrix.pkgbuild_dir }}
+      VARIANT_KIND: ${{ matrix.kind }}
       GH_REPO: jondkinney/tensaku
       TAG: ${{ github.event.release.tag_name || inputs.tag }}
     steps:
@@ -33,17 +53,16 @@ jobs:
           set -euo pipefail
           ver="${TAG#v}"
 
-          # SSH access to the AUR. Pass options inline via
-          # GIT_SSH_COMMAND so we don't depend on ~/.ssh/config being
-          # honored — accept-new writes the AUR's host key to
-          # known_hosts on first connect (TOFU).
+          # SSH access to the AUR. Inline -o flags via GIT_SSH_COMMAND
+          # so we don't depend on ~/.ssh/config being honored —
+          # accept-new TOFUs the AUR's host key on first connect.
           install -dm700 /root/.ssh
           echo "$AUR_SSH_KEY" > /root/.ssh/id_aur
           chmod 600 /root/.ssh/id_aur
           touch /root/.ssh/known_hosts
           export GIT_SSH_COMMAND='ssh -i /root/.ssh/id_aur -o IdentitiesOnly=yes -o StrictHostKeyChecking=accept-new -o UserKnownHostsFile=/root/.ssh/known_hosts'
 
-          # Grab packaging/aur/PKGBUILD at the released tag.
+          # Grab the variant's PKGBUILD at the released tag.
           git clone --depth 1 --branch "$TAG" "https://github.com/$GH_REPO.git" app
 
           # Clone the AUR repo; init a fresh one if the package is new.
@@ -53,16 +72,53 @@ jobs:
             git -C aur remote add origin "ssh://aur@aur.archlinux.org/${AUR_PKG}.git"
           fi
 
-          # Drop in the PKGBUILD, pinned to this release.
-          cp app/packaging/aur/PKGBUILD aur/PKGBUILD
-          sed -i "s/^pkgver=.*/pkgver=$ver/;s/^pkgrel=.*/pkgrel=1/" aur/PKGBUILD
+          # Drop in the variant's PKGBUILD.
+          cp "app/packaging/${PKGBUILD_DIR}/PKGBUILD" aur/PKGBUILD
+
+          # Variant-specific version pin + tarball wait.
+          case "$VARIANT_KIND" in
+            source)
+              sed -i "s/^pkgver=.*/pkgver=$ver/;s/^pkgrel=.*/pkgrel=1/" aur/PKGBUILD
+              ;;
+            bin)
+              # The linux-tarball job in release.yml builds the
+              # bundled tarball in parallel with this workflow. Wait
+              # up to ~30 min for it to land on the GitHub Release
+              # before updpkgsums tries to fetch it.
+              sed -i "s/^pkgver=.*/pkgver=$ver/;s/^pkgrel=.*/pkgrel=1/" aur/PKGBUILD
+              tarball_url="https://github.com/${GH_REPO}/releases/download/${TAG}/tensaku-${TAG}-x86_64.tar.gz"
+              for i in $(seq 1 90); do
+                if curl -sfIL -o /dev/null "$tarball_url"; then
+                  echo "linux tarball present"
+                  break
+                fi
+                echo "waiting for linux tarball (attempt $i/90)..."
+                sleep 20
+              done
+              ;;
+            git)
+              # Static pkgver= line is metadata only — the pkgver()
+              # function regenerates it at build time. Bump it to the
+              # new tag so the AUR page shows the current version.
+              # sha256sums=('SKIP'), so no updpkgsums needed.
+              sed -i "s/^pkgver=.*/pkgver=$ver/" aur/PKGBUILD
+              ;;
+          esac
 
           # makepkg / updpkgsums refuse to run as root.
           useradd -m builder
           chown -R builder:builder aur
-          sudo -H -u builder bash -c 'cd aur && updpkgsums && makepkg --printsrcinfo > .SRCINFO'
 
-          # Commit + push.
+          case "$VARIANT_KIND" in
+            source|bin)
+              sudo -H -u builder bash -c 'cd aur && updpkgsums && makepkg --printsrcinfo > .SRCINFO'
+              ;;
+            git)
+              sudo -H -u builder bash -c 'cd aur && makepkg --printsrcinfo > .SRCINFO'
+              ;;
+          esac
+
+          # Commit + push (no-op if nothing changed).
           git config --global --add safe.directory "$PWD/aur"
           cd aur
           git config user.name 'tensaku release'

--- a/packaging/aur-bin/PKGBUILD
+++ b/packaging/aur-bin/PKGBUILD
@@ -1,0 +1,33 @@
+# Maintainer: Jon Kinney
+#
+# Source of truth for the AUR `tensaku-bin` package — prebuilt binary
+# from the GitHub Release. The release.yml `linux-tarball` job runs
+# `make package` which produces tensaku-v<ver>-x86_64.tar.gz with a
+# /usr-style layout inside (bin/, share/applications, etc.).
+# aur-publish.yml copies this file, pins pkgver/pkgrel, refreshes
+# sha256sums with updpkgsums, regenerates .SRCINFO, and pushes.
+pkgname=tensaku-bin
+_pkgname=tensaku
+pkgver=0.25.0
+pkgrel=1
+pkgdesc='Modern screenshot annotation tool for Wayland (prebuilt binary)'
+arch=('x86_64')
+url='https://github.com/jondkinney/tensaku'
+license=('MPL-2.0')
+depends=('gtk4' 'gtk4-layer-shell' 'libadwaita' 'libepoxy' 'fontconfig')
+provides=("$_pkgname=$pkgver")
+conflicts=("$_pkgname" "$_pkgname-git")
+source=("$_pkgname-v$pkgver-x86_64.tar.gz::https://github.com/jondkinney/$_pkgname/releases/download/v$pkgver/$_pkgname-v$pkgver-x86_64.tar.gz")
+# Placeholder — CI's updpkgsums overwrites with the real hash per release.
+sha256sums=('0000000000000000000000000000000000000000000000000000000000000000')
+
+package() {
+  # `make package` tarballs the install-staged tree, so we just need
+  # to drop bin/ and share/ under /usr.
+  install -d "$pkgdir/usr"
+  cp -a "$srcdir/bin" "$srcdir/share" "$pkgdir/usr/"
+  # The Makefile's install target writes licenses under share/licenses/
+  # tensaku/; rename to match this package's name so makepkg's
+  # license-check picks them up.
+  mv "$pkgdir/usr/share/licenses/$_pkgname" "$pkgdir/usr/share/licenses/$pkgname"
+}

--- a/packaging/aur-git/PKGBUILD
+++ b/packaging/aur-git/PKGBUILD
@@ -1,0 +1,60 @@
+# Maintainer: Jon Kinney
+#
+# Source of truth for the AUR `tensaku-git` package — tracks main.
+# The pkgver() function regenerates the version from `git describe`
+# at build time; the static pkgver= line below is metadata only (for
+# AUR display). aur-publish.yml bumps that line on each release.
+pkgname=tensaku-git
+_pkgname=tensaku
+pkgver=0.25.0.r0.gabcdef
+pkgrel=1
+pkgdesc='Modern screenshot annotation tool for Wayland (latest main)'
+arch=('x86_64')
+url='https://github.com/jondkinney/tensaku'
+license=('MPL-2.0')
+depends=('gtk4' 'gtk4-layer-shell' 'libadwaita' 'libepoxy' 'fontconfig')
+makedepends=('rust' 'git')
+provides=("$_pkgname=$pkgver")
+conflicts=("$_pkgname" "$_pkgname-bin")
+source=("$_pkgname::git+https://github.com/jondkinney/$_pkgname.git")
+sha256sums=('SKIP')
+
+pkgver() {
+  cd "$_pkgname"
+  # <last-tag>.r<commits-since>.g<short-hash> — sortable + uniquely
+  # identifies the commit. Strip the `v` prefix; rewrite the
+  # `-N-g<sha>` git-describe suffix to `.rN.g<sha>` for pacman.
+  git describe --long --tags --abbrev=7 \
+    | sed 's/^v//;s/\([^-]*-g\)/r\1/;s/-/./g'
+}
+
+prepare() {
+  cd "$_pkgname"
+  export RUSTUP_TOOLCHAIN=stable
+  cargo fetch --locked --target "$(rustc -vV | sed -n 's/host: //p')"
+}
+
+build() {
+  cd "$_pkgname"
+  export RUSTUP_TOOLCHAIN=stable
+  export CARGO_TARGET_DIR=target
+  cargo build --frozen --release --features ci-release
+}
+
+package() {
+  cd "$_pkgname"
+  install -Dm755 target/release/tensaku "$pkgdir/usr/bin/tensaku"
+  install -Dm644 dev.tensaku.Tensaku.desktop \
+    "$pkgdir/usr/share/applications/dev.tensaku.Tensaku.desktop"
+  install -Dm644 assets/tensaku.svg \
+    "$pkgdir/usr/share/icons/hicolor/scalable/apps/dev.tensaku.Tensaku.svg"
+  install -Dm644 man/tensaku.1 "$pkgdir/usr/share/man/man1/tensaku.1"
+  install -Dm644 completions/tensaku.bash \
+    "$pkgdir/usr/share/bash-completion/completions/tensaku"
+  install -Dm644 completions/tensaku.fish \
+    "$pkgdir/usr/share/fish/vendor_completions.d/tensaku.fish"
+  install -Dm644 completions/_tensaku \
+    "$pkgdir/usr/share/zsh/site-functions/_tensaku"
+  install -Dm644 LICENSE "$pkgdir/usr/share/licenses/$pkgname/LICENSE"
+  install -Dm644 NOTICE "$pkgdir/usr/share/licenses/$pkgname/NOTICE"
+}


### PR DESCRIPTION
## What

Adds two new AUR variants alongside the existing source build:

| Variant | Source | Notes |
|---|---|---|
| `tensaku` (existing) | GitHub source tarball | Builds from source |
| **`tensaku-bin`** *(new)* | `linux-tarball` release asset | Fast install, no compile |
| **`tensaku-git`** *(new)* | `git+https://...main` | Always latest; `pkgver()` from `git describe` |

## Changes

- **`packaging/aur-bin/PKGBUILD`** — prebuilt-binary AUR package. Sources the `tensaku-vX.Y.Z-x86_64.tar.gz` asset that the existing `linux-tarball` job (running `make package`) attaches to every release. Unpacks its /usr-style layout straight into `$pkgdir/usr`.
- **`packaging/aur-git/PKGBUILD`** — git-tracking AUR package. `sha256sums=('SKIP')` + `pkgver()` from `git describe`.
- **`.github/workflows/aur-publish.yml`** — converted to a matrix of all three variants (source / bin / git). The bin variant polls ~30 min for the Linux tarball to land on the GitHub Release before `updpkgsums` pins the sha. Pattern matches mousehop's and vernier's.

## No release.yml change

Tensaku already produces the bundled tarball via `make package` (binary + desktop + icon + completions + man + LICENSE + NOTICE), so nothing to restructure on the release side.

## After merge

The next real `feat:`/`fix:` release will push all three AUR variants (creating `tensaku-bin` and `tensaku-git` on first run).

Both new variants `conflict` with `tensaku` and each other, so users pick one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)