### PR TITLE
ci(flatpak): build + attach Flatpak bundle on every release

### DIFF
--- a/.github/workflows/release-flatpak.yml
+++ b/.github/workflows/release-flatpak.yml
@@ -1,0 +1,78 @@
+name: release-flatpak
+
+# Build the Flatpak bundle for tensaku on every published Release
+# and attach it as a Release asset. Mirrors the workflow shape used
+# by mousehop and vernier; the manifest itself
+# (dev.tensaku.Tensaku.yml at the repo root) was already in place,
+# ported from upstream satty during the fork-rename.
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Release tag to build (e.g. v0.26.0)'
+        required: true
+        type: string
+      ref:
+        # Validation knob: when set (e.g. `main`), the build comes
+        # from that ref instead of the tag, and the resulting bundle
+        # is NOT attached to the Release. Use this to verify a
+        # manifest change before cutting a release. Leave blank for
+        # the normal backfill-an-old-tag path.
+        description: 'Git ref to build from (default: the tag itself). Set to a branch (e.g. main) to validate without attaching to the Release.'
+        required: false
+        type: string
+
+jobs:
+  flatpak-build:
+    name: Build Flatpak bundle
+    runs-on: ubuntu-latest
+    permissions:
+      # gh release upload writes to the release assets.
+      contents: write
+    container:
+      image: ghcr.io/flathub-infra/flatpak-github-actions:gnome-49
+      options: --privileged
+    steps:
+      - name: Resolve target tag
+        id: tag
+        run: |
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            TAG="${{ inputs.tag }}"
+          else
+            TAG="${{ github.event.release.tag_name }}"
+          fi
+          echo "tag=$TAG" >> "$GITHUB_OUTPUT"
+          echo "Building Flatpak for $TAG"
+
+      - name: Checkout source
+        # Falls through to the tag on release events (where
+        # inputs.ref is empty) and on dispatches that leave `ref`
+        # blank. Only an explicit override changes the source.
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.ref || steps.tag.outputs.tag }}
+
+      - name: Build bundle
+        uses: flatpak/flatpak-github-actions/flatpak-builder@v6
+        with:
+          bundle: tensaku.flatpak
+          manifest-path: dev.tensaku.Tensaku.yml
+          cache-key: flatpak-builder-${{ github.sha }}
+
+      - name: Upload bundle to GitHub Release
+        # Skip the upload when this is a validation run (inputs.ref
+        # is set). The bundle is still preserved as a GH Actions
+        # artifact by the flatpak-builder action above, so it can
+        # be downloaded for inspection without polluting Release
+        # assets.
+        if: inputs.ref == ''
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh release upload "${{ steps.tag.outputs.tag }}" \
+            tensaku.flatpak \
+            --repo "$GITHUB_REPOSITORY" \
+            --clobber


### PR DESCRIPTION
## Summary

Adds the missing piece of tensaku's Flatpak story — a GitHub Actions workflow that fires on every published Release, builds the bundle from the existing manifest at the repo root (`dev.tensaku.Tensaku.yml`), and attaches `tensaku.flatpak` as a Release asset.

The manifest was already production-shape (ported from upstream satty during the fork-rename, with a `gtk4-layer-shell` module build added for the scroll-capture overlay). This PR just wires it into CI.

## Behavior

Mirrors `release-flatpak.yml` in jondkinney/vernier (post–PR #7):

| Event | `inputs.ref` | Builds from | Uploads to Release |
|---|---|---|---|
| `release: published` | (empty) | release tag | yes |
| `workflow_dispatch` (no ref) | (empty) | input tag | yes (backfill path) |
| `workflow_dispatch` ref=`main` | `main` | main | **no** (validation path) |

When the upload is skipped, the bundle is still preserved as a GitHub Actions artifact by the `flatpak-builder` action's built-in upload, so it can be downloaded for inspection.

## Differences from vernier's workflow

- Container image: `gnome-49` instead of `freedesktop-24.08` — the manifest targets `org.gnome.Platform//49` because tensaku is a GTK app (vernier is winit/wgpu).
- Manifest path: `dev.tensaku.Tensaku.yml` at the repo root, not under `build-aux/`. That's the upstream-satty convention and tensaku inherited it.
- Bundle filename: `tensaku.flatpak`.

## Test plan

- [ ] Merge.
- [ ] `gh workflow run release-flatpak.yml --repo jondkinney/tensaku --field tag=v0.25.0 --field ref=main` — validates the existing manifest builds end-to-end against current HEAD, without attaching anything to v0.25.0's Release.
- [ ] If it succeeds: download the artifact from the run page, `flatpak install --user tensaku.flatpak && flatpak run dev.tensaku.Tensaku`.
- [ ] Iterate on `finish-args` / portal permissions if anything is denied at runtime.

🤖 Generated with [Claude Code](https://claude.com/claude-code)