### PR TITLE
chore(flatpak): narrow socket=x11 to fallback-x11

### DIFF
--- a/dev.tensaku.Tensaku.yml
+++ b/dev.tensaku.Tensaku.yml
@@ -14,9 +14,10 @@ build-options:
     CARGO_REGISTRIES_CRATES_IO_PROTOCOL: sparse
     RUSTFLAGS: -C link-arg=-Wl,-z,now
 finish-args:
-  # Wayland support
+  # Wayland support; fallback-x11 only grants X11 access when
+  # Wayland isn't available — tighter than --socket=x11.
   - --socket=wayland
-  - --socket=x11
+  - --socket=fallback-x11
   - --device=dri
   # File access
   - --filesystem=home


### PR DESCRIPTION
## Summary

\`fallback-x11\` only grants X11 access when Wayland isn't available at runtime — same Wayland-first stance as vernier and mousehop's Flatpak manifests. The broader \`--socket=x11\` was unnecessary since tensaku's primary target has always been wlroots.

One-liner change.

## Test plan

- [ ] Merge.
- [ ] \`gh workflow run release-flatpak.yml --repo jondkinney/tensaku --field tag=v0.25.0 --field ref=main\` — confirm bundle still builds clean.
- [ ] (Optional) sideload + confirm X11 fallback still works on a non-Wayland session if you have one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)