### PR TITLE
feat(flatpak): add Flathub screenshot to metainfo

### DIFF
--- a/dev.tensaku.Tensaku.metainfo.xml
+++ b/dev.tensaku.Tensaku.metainfo.xml
@@ -16,6 +16,12 @@
       Tensaku is a fork of Satty by Matthias Gabriel, used under the MPL-2.0 license.
     </p>
   </description>
+  <screenshots>
+    <screenshot type="default">
+      <caption>The annotation canvas with the layer panel open — every mark stays selectable, draggable, and re-orderable</caption>
+      <image>https://tensaku.dev/assets/screenshot-layer-panel.png</image>
+    </screenshot>
+  </screenshots>
   <categories>
     <category>Utility</category>
     <category>Graphics</category>


### PR DESCRIPTION
## Summary

Adds the canonical product screenshot to the Tensaku Flatpak metainfo, referencing \`https://tensaku.dev/assets/screenshot-layer-panel.png\` (already in the site repo). Picks the layer-panel screenshot because it's the headline differentiator from upstream satty.

This is the last Flathub-required element. With this in place, the metainfo now has every block Flathub requires.

## Test plan

- [ ] Merge.
- [ ] \`gh workflow run release-flatpak.yml --repo jondkinney/tensaku --field tag=v0.25.0 --field ref=main\` — bundle should still build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)