### PR TITLE
feat(flatpak): render hicolor PNG icon ladder at build time

### DIFF
--- a/dev.tensaku.Tensaku.yml
+++ b/dev.tensaku.Tensaku.yml
@@ -56,6 +56,17 @@ modules:
       - install -Dm644 dev.tensaku.Tensaku.desktop /app/share/applications/dev.tensaku.Tensaku.desktop
       - install -Dm644 dev.tensaku.Tensaku.metainfo.xml /app/share/metainfo/dev.tensaku.Tensaku.metainfo.xml
       - install -Dm644 assets/tensaku.svg /app/share/icons/hicolor/scalable/apps/dev.tensaku.Tensaku.svg
+      # Render a hicolor PNG ladder from the source SVG so hosts
+      # that prefer fixed-size raster icons (older toolkits, certain
+      # KDE variants) get a sharp render without scaling the SVG at
+      # runtime. rsvg-convert ships with the GNOME runtime.
+      - |
+        for size in 16 22 24 32 48 64 128 256 512; do
+          install -d /app/share/icons/hicolor/${size}x${size}/apps
+          rsvg-convert -w $size -h $size \
+            assets/tensaku.svg \
+            -o /app/share/icons/hicolor/${size}x${size}/apps/dev.tensaku.Tensaku.png
+        done
       - install -Dm644 LICENSE /app/share/licenses/dev.tensaku.Tensaku/LICENSE
       - install -Dm644 NOTICE /app/share/licenses/dev.tensaku.Tensaku/NOTICE
       - install -Dm644 completions/tensaku.bash /app/share/bash-completion/completions/tensaku


### PR DESCRIPTION
## Summary

Renders the source SVG into a full hicolor PNG ladder (16/22/24/32/48/64/128/256/512) at Flatpak build time using \`rsvg-convert\` from the GNOME runtime, installing each into \`/app/share/icons/hicolor/<size>x<size>/apps/dev.tensaku.Tensaku.png\`.

Same diff shape just opened against mousehop + vernier in parallel.

## Why build-time

Zero committed binaries: every PNG is regenerated from the SVG on every build, so the source of truth never drifts past the SVG. The repo had no PNGs to begin with, so this is the cleanest way to add the ladder.

## Test plan

- [ ] Merge.
- [ ] \`gh workflow run release-flatpak.yml --repo jondkinney/tensaku --field tag=v0.25.0 --field ref=main\` — bundle should still build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)