### PR TITLE
feat(metainfo): auto-fill Flathub release notes from CHANGELOG

### DIFF
--- a/.github/workflows/release-update-metainfo.yml
+++ b/.github/workflows/release-update-metainfo.yml
@@ -1,0 +1,110 @@
+name: release-update-metainfo
+
+# Prepend a per-version <release><description> block to the Flatpak
+# metainfo XML whenever a new GitHub Release is published. The
+# description body is parsed from the matching CHANGELOG.md
+# section so Flathub's Version-history shows real notes instead
+# of an empty stub.
+#
+# Mirrors release-update-site.yml's "fire on release, mutate a
+# file in this repo, push back" shape. Idempotent: if the
+# metainfo already references the version, the run is a no-op.
+#
+# Tensaku's CHANGELOG.md doesn't exist yet — release-plz will
+# create it on the next release. The script tolerates a missing
+# CHANGELOG and emits a minimal <release> block in that case.
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Release tag to record (e.g. v0.26.0)'
+        required: true
+        type: string
+
+jobs:
+  update:
+    name: Update metainfo from CHANGELOG
+    runs-on: ubuntu-latest
+    permissions:
+      # Needed so the default GITHUB_TOKEN can push the follow-up
+      # commit back to main.
+      contents: write
+    env:
+      METAINFO: dev.tensaku.Tensaku.metainfo.xml
+      CHANGELOG: CHANGELOG.md
+    steps:
+      - name: Resolve tag / version / date
+        id: meta
+        run: |
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            TAG="${{ inputs.tag }}"
+          else
+            TAG="${{ github.event.release.tag_name }}"
+          fi
+          VERSION="${TAG#v}"
+          DATE=$(date -u +%Y-%m-%d)
+          echo "tag=$TAG"         >> "$GITHUB_OUTPUT"
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          echo "date=$DATE"       >> "$GITHUB_OUTPUT"
+          echo "Recording $TAG (version $VERSION, date $DATE) in $METAINFO"
+
+      - uses: actions/checkout@v4
+        with:
+          ref: main
+
+      - name: Skip if metainfo already references this version
+        id: idempotency
+        run: |
+          if grep -q "version=\"${{ steps.meta.outputs.version }}\"" "$METAINFO"; then
+            echo "metainfo already has version ${{ steps.meta.outputs.version }} — no-op"
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "changed=true"  >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Generate <release> XML block from CHANGELOG
+        if: steps.idempotency.outputs.changed == 'true'
+        id: gen
+        run: |
+          python3 scripts/gen_appstream_release.py \
+            "$CHANGELOG" \
+            "${{ steps.meta.outputs.version }}" \
+            "${{ steps.meta.outputs.date }}" > /tmp/release.xml
+          echo "--- generated block ---"
+          cat /tmp/release.xml
+
+      - name: Insert block into metainfo
+        if: steps.idempotency.outputs.changed == 'true'
+        run: |
+          # Python over sed to avoid escape pain with the multi-line
+          # block. Inserts the new <release> right after the
+          # <releases> opening tag with 4-space indentation.
+          python3 - "$METAINFO" /tmp/release.xml <<'PY'
+          import pathlib, re, sys
+          meta = pathlib.Path(sys.argv[1])
+          xml  = meta.read_text(encoding="utf-8")
+          block = pathlib.Path(sys.argv[2]).read_text(encoding="utf-8").rstrip()
+          indented = "\n".join("    " + line for line in block.split("\n"))
+          new = re.sub(
+              r"(<releases>\s*\n)",
+              r"\1" + indented + "\n",
+              xml,
+              count=1,
+          )
+          if new == xml:
+              raise SystemExit("could not find <releases> tag to patch")
+          meta.write_text(new, encoding="utf-8")
+          PY
+          git --no-pager diff -- "$METAINFO" | head -60
+
+      - name: Commit + push
+        if: steps.idempotency.outputs.changed == 'true'
+        run: |
+          git config user.name  "tensaku-release-bot"
+          git config user.email "tensaku-release-bot@users.noreply.github.com"
+          git add "$METAINFO"
+          git commit -m "chore(metainfo): record release ${{ steps.meta.outputs.tag }}"
+          git push origin main

--- a/scripts/gen_appstream_release.py
+++ b/scripts/gen_appstream_release.py
@@ -1,0 +1,105 @@
+#!/usr/bin/env python3
+"""Generate an AppStream <release> XML block from a CHANGELOG.md entry.
+
+Usage:
+    gen_appstream_release.py CHANGELOG.md VERSION DATE
+
+Writes the resulting XML to stdout. The AppStream description
+subset accepts only <p>, <ul>, and <li>, so the script converts
+Keep-a-Changelog subsections into that shape.
+
+If the CHANGELOG file doesn't exist, the version section isn't
+found, or the section has no bullet items, a minimal
+<release version="X" date="Y"/> is emitted (still valid AppStream).
+The post-release workflow uses idempotent metainfo patching, so a
+stub entry will simply be left alone on subsequent runs.
+
+CHANGELOG format expected (Keep a Changelog):
+
+    ## [VERSION] - DATE              (with or without a compare-URL)
+    ### Added
+    - feature one
+    - *(scope)* feature two          (conventional-commit scope is stripped)
+    ### Fixed
+    - bug
+"""
+from __future__ import annotations
+
+import html
+import os.path
+import re
+import sys
+
+
+def emit_minimal(version: str, date: str) -> None:
+    print(f'<release version="{version}" date="{date}"/>')
+
+
+def main() -> int:
+    if len(sys.argv) != 4:
+        print(
+            "usage: gen_appstream_release.py CHANGELOG.md VERSION DATE",
+            file=sys.stderr,
+        )
+        return 2
+    changelog_path, version, date = sys.argv[1], sys.argv[2], sys.argv[3]
+
+    if not os.path.isfile(changelog_path):
+        emit_minimal(version, date)
+        return 0
+
+    with open(changelog_path, encoding="utf-8") as f:
+        content = f.read()
+
+    # Match `## [VERSION]` with or without a compare-URL link.
+    pattern = re.compile(
+        r"^## \[" + re.escape(version) + r"\][^\n]*\n(.*?)(?=\n## \[|\Z)",
+        re.MULTILINE | re.DOTALL,
+    )
+    match = pattern.search(content)
+    if not match:
+        emit_minimal(version, date)
+        return 0
+
+    section = match.group(1).strip()
+    # Split on `### Header` lines into ['', 'Header1', body1, 'Header2', body2, ...].
+    subsections = re.split(r"^### (\w+)\s*\n", section, flags=re.MULTILINE)
+
+    parts: list[str] = []
+    for i in range(1, len(subsections), 2):
+        header = subsections[i]
+        body = subsections[i + 1] if i + 1 < len(subsections) else ""
+        items: list[str] = []
+        for line in body.split("\n"):
+            stripped = line.strip()
+            if not stripped.startswith("- "):
+                continue
+            item = stripped[2:].strip()
+            # Strip conventional-commit scope: `*(desktop)* foo` -> `foo`.
+            item = re.sub(r"^\*\([^)]+\)\*\s*", "", item)
+            # Collapse internal whitespace from line wraps.
+            item = re.sub(r"\s+", " ", item)
+            if item:
+                items.append(html.escape(item))
+        if items:
+            parts.append(f"<p>{header}:</p>")
+            parts.append("<ul>")
+            for item in items:
+                parts.append(f"  <li>{item}</li>")
+            parts.append("</ul>")
+
+    if not parts:
+        emit_minimal(version, date)
+        return 0
+
+    print(f'<release version="{version}" date="{date}">')
+    print("  <description>")
+    for part in parts:
+        print(f"    {part}")
+    print("  </description>")
+    print("</release>")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

Adds \`release-update-metainfo.yml\` — a post-release workflow that fires on \`release: published\`, parses the matching \`CHANGELOG.md\` section, converts it to the AppStream description subset, and prepends a fresh \`<release>\` block to \`dev.tensaku.Tensaku.metainfo.xml\`.

Same diff opening in parallel against mousehop + vernier.

## Tensaku-specific note

Tensaku doesn't have a \`CHANGELOG.md\` yet — release-plz will create one on the next release that touches a workspace member. The script tolerates a missing CHANGELOG and emits a minimal \`<release version="X" date="Y"/>\` rather than failing, so the workflow is safe to merge now and will start producing rich entries once release-plz writes the CHANGELOG.

## Behavior

- Trigger: \`release: published\` plus \`workflow_dispatch\` backfill input.
- Idempotent: no-op if version already in metainfo.
- Fallback: missing CHANGELOG / section / bullets → minimal \`<release/>\`.

## Test plan

- [ ] Merge.
- [ ] \`gh workflow run release-update-metainfo.yml --repo jondkinney/tensaku --field tag=v0.25.0\` — should report "metainfo already has version 0.25.0 — no-op".
- [ ] Next real release: minimal \`<release/>\` block prepended (richer once CHANGELOG.md exists).

🤖 Generated with [Claude Code](https://claude.com/claude-code)