### PR TITLE
fix(scaling): correct screenshot sizing & sharpness on fractional-scale monitors

### DIFF
--- a/src/display.rs
+++ b/src/display.rs
@@ -7,6 +7,32 @@
 //! expose fractional scales (1.25×, 1.5×) reliably.
 
 use std::process::Command;
+use std::sync::OnceLock;
+
+/// The fractional scale the screenshot being edited was captured at,
+/// resolved once and cached. `grim` hands us capture-native (device)
+/// pixels with no scale metadata, so to map them back to logical
+/// ("1×") pixels we need the compositor's fractional output scale —
+/// GTK's `scale_factor()` only exposes the rounded-up integer
+/// (a 1.07× output reports `2`, which would render the image at
+/// roughly half size).
+///
+/// Resolution order: an explicit `input_scale` config override wins;
+/// otherwise the focused Hyprland monitor's fractional `scale`.
+/// Returns `None` when neither is available (not Hyprland, no
+/// override) — callers then fall back to GTK's integer `scale_factor`,
+/// which reproduces the pre-fractional behaviour exactly.
+pub fn capture_scale() -> Option<f32> {
+    static CACHE: OnceLock<Option<f32>> = OnceLock::new();
+    *CACHE.get_or_init(|| {
+        let input_scale = crate::APP_CONFIG.read().input_scale();
+        if input_scale != 1.0 {
+            Some(input_scale)
+        } else {
+            detect_hyprland_scale()
+        }
+    })
+}
 
 /// Try to read the focused monitor's scale from Hyprland. Returns
 /// `None` when not running under Hyprland or when `hyprctl` is missing

--- a/src/femtovg_area/imp.rs
+++ b/src/femtovg_area/imp.rs
@@ -563,11 +563,13 @@ impl GLAreaImpl for FemtoVGArea {
         // update scale factor + pan; capture the snapshot we need
         // for the upstream notifications BEFORE releasing the inner
         // borrow so the emit paths don't have to re-acquire it.
-        // `effective_scale` is what the indicator should show — for
-        // committed-crop mode it's `crop_zoom`, for the regular view
-        // it equals `scale_factor`. update_transformation keeps it in
-        // sync now, so one emit covers both paths.
-        let (eff_scale, pan_info, min_canvas_h) = {
+        // The zoom indicator shows a *user-facing* zoom where 100% is
+        // the image at its true 1× logical size. Internally that's
+        // `effective_scale` (a render scale whose 100% is
+        // `natural_scale()`, not 1.0), so divide it back out before
+        // emitting — otherwise a fractional-scaling output would read
+        // e.g. "187%" at the fit-to-window view.
+        let (display_zoom, pan_info, min_canvas_h) = {
             let mut inner_ref = self.inner();
             let inner = inner_ref
                 .as_mut()
@@ -596,12 +598,12 @@ impl GLAreaImpl for FemtoVGArea {
                 canvas_h: canvas.height() as f32,
             };
             (
-                inner.effective_scale,
+                inner.effective_scale / inner.natural_scale(),
                 pan_info,
                 inner.min_canvas_height_logical(),
             )
         };
-        self.notify_zoom_display(eff_scale);
+        self.notify_zoom_display(display_zoom);
         self.notify_pan_display(pan_info);
         self.apply_vertical_resize_floor(min_canvas_h);
     }
@@ -891,15 +893,25 @@ impl FemtoVGArea {
 }
 
 /// Auto-fit scale that fits `content` (device px) inside the padded
-/// `inner` area, capped at 1:1. The *vertical* fit term is floored at
-/// `MIN_AUTO_FIT_ZOOM`: shrinking the window's height — including a
-/// tiling-WM resize that ignores our `outer_box` min-size request —
-/// can't squeeze the image past that zoom; the canvas clips it
-/// instead. The horizontal term is left unfloored, matching the
-/// height-only `min_canvas_height_logical` / size-request floor.
-fn auto_fit_scale(inner_w: f32, inner_h: f32, content_w: f32, content_h: f32) -> f32 {
+/// `inner` area, capped at `max_scale` — the render scale at which the
+/// image displays at its true 1× logical size (see
+/// `FemtoVgAreaMut::natural_scale`; it's 1.0 on integer-scaled
+/// displays and >1 on fractional-scaling outputs). The *vertical* fit
+/// term is floored at `MIN_AUTO_FIT_ZOOM`: shrinking the window's
+/// height — including a tiling-WM resize that ignores our `outer_box`
+/// min-size request — can't squeeze the image past that zoom; the
+/// canvas clips it instead. The horizontal term is left unfloored,
+/// matching the height-only `min_canvas_height_logical` /
+/// size-request floor.
+fn auto_fit_scale(
+    inner_w: f32,
+    inner_h: f32,
+    content_w: f32,
+    content_h: f32,
+    max_scale: f32,
+) -> f32 {
     let fit_h = (inner_h / content_h).max(MIN_AUTO_FIT_ZOOM);
-    (inner_w / content_w).min(fit_h).min(1.0)
+    (inner_w / content_w).min(fit_h).min(max_scale)
 }
 
 impl FemtoVgAreaMut {
@@ -1712,7 +1724,13 @@ impl FemtoVgAreaMut {
             let pad = CANVAS_PADDING_CSS * self.device_pixel_ratio.max(0.0001);
             let inner_w = (canvas_w - 2.0 * pad).max(canvas_w * 0.5).max(1.0);
             let inner_h = (canvas_h - 2.0 * pad).max(canvas_h * 0.5).max(1.0);
-            let base_scale = auto_fit_scale(inner_w, inner_h, crop_size.x, crop_size.y);
+            let base_scale = auto_fit_scale(
+                inner_w,
+                inner_h,
+                crop_size.x,
+                crop_size.y,
+                self.natural_scale(),
+            );
             let scale = base_scale * self.crop_zoom;
             let crop_canvas_w = crop_size.x * scale;
             let crop_canvas_h = crop_size.y * scale;
@@ -2483,6 +2501,27 @@ impl FemtoVgAreaMut {
         }
     }
 
+    /// Render scale at which the background image displays at its true
+    /// 1× logical size — i.e. what "100% zoom" means for this capture.
+    ///
+    /// The image arrives as capture-native (device) pixels. The GL
+    /// canvas renders into a framebuffer `device_pixel_ratio`× the
+    /// logical canvas. So an image drawn at render scale `s` occupies
+    /// `image_px · s / device_pixel_ratio` logical pixels. For that to
+    /// equal the image's own logical size (`image_px / capture_scale`)
+    /// the render scale must be `device_pixel_ratio / capture_scale`.
+    ///
+    /// On integer-scaled displays the capture scale equals the GL DPR,
+    /// so this is exactly `1.0` and nothing changes. On a fractional
+    /// output (e.g. 1.07× — where GTK rounds the GL DPR up to 2) it's
+    /// `2 / 1.07 ≈ 1.87`, which is what stops the screenshot from
+    /// rendering at roughly half size.
+    fn natural_scale(&self) -> f32 {
+        let dpr = self.device_pixel_ratio.max(0.0001);
+        let capture = crate::display::capture_scale().unwrap_or(dpr).max(0.0001);
+        dpr / capture
+    }
+
     pub fn update_transformation(
         &mut self,
         canvas: &mut femtovg::Canvas<femtovg::renderer::OpenGl>,
@@ -2534,7 +2573,13 @@ impl FemtoVgAreaMut {
             let inner_h = (canvas_height - 2.0 * pad)
                 .max(canvas_height * 0.5)
                 .max(1.0);
-            self.scale_factor = auto_fit_scale(inner_w, inner_h, image_width, image_height);
+            self.scale_factor = auto_fit_scale(
+                inner_w,
+                inner_h,
+                image_width,
+                image_height,
+                self.natural_scale(),
+            );
         }
 
         // `effective_scale` is what the zoom indicator should show:
@@ -2558,7 +2603,13 @@ impl FemtoVgAreaMut {
             let inner_h = (canvas_height - 2.0 * pad)
                 .max(canvas_height * 0.5)
                 .max(1.0);
-            auto_fit_scale(inner_w, inner_h, crop_size.x, crop_size.y) * self.crop_zoom
+            auto_fit_scale(
+                inner_w,
+                inner_h,
+                crop_size.x,
+                crop_size.y,
+                self.natural_scale(),
+            ) * self.crop_zoom
         } else {
             self.scale_factor
         };
@@ -2783,21 +2834,30 @@ impl FemtoVgAreaMut {
         // user can only see a sliver of the image (above 500%).
         // `factor == 0.0` is the FitCanvas sentinel — preserved as-is
         // so `update_transformation` re-enters the auto-fit branch.
+        //
+        // `zoom_scale` is stored as a *render* scale (the transform
+        // fed to `t.scale`), where `natural_scale()` — not 1.0 — is
+        // 100%. So the user-facing limits and an absolute `factor`
+        // (which arrives in user-zoom terms, 1.0 = 100%) are both
+        // mapped through `natural`. A relative `factor` is a plain
+        // ratio and needs no mapping; only its clamp bounds do.
         const MIN_ZOOM: f32 = 0.10;
         const MAX_ZOOM: f32 = 5.00;
+        let natural = self.natural_scale();
+        let (min_render, max_render) = (MIN_ZOOM * natural, MAX_ZOOM * natural);
 
         if abs {
             if factor == 0.0 {
                 self.zoom_scale = 0.0;
             } else {
-                self.zoom_scale = factor.clamp(MIN_ZOOM, MAX_ZOOM);
+                self.zoom_scale = (factor * natural).clamp(min_render, max_render);
             }
         } else {
             if self.zoom_scale == 0.0 {
                 self.zoom_scale = self.scale_factor;
             }
 
-            self.zoom_scale = (self.zoom_scale * factor).clamp(MIN_ZOOM, MAX_ZOOM);
+            self.zoom_scale = (self.zoom_scale * factor).clamp(min_render, max_render);
         }
     }
 

--- a/src/femtovg_area/imp.rs
+++ b/src/femtovg_area/imp.rs
@@ -1741,8 +1741,11 @@ impl FemtoVgAreaMut {
             self.drag_offset.x = self.drag_offset.x.clamp(-excess_x / 2.0, excess_x / 2.0);
             self.drag_offset.y = self.drag_offset.y.clamp(-excess_y / 2.0, excess_y / 2.0);
             self.last_offset = self.drag_offset;
-            let offset_x = pad_x - scale * crop_pos.x + self.drag_offset.x;
-            let offset_y = pad_y - scale * crop_pos.y + self.drag_offset.y;
+            // Round to whole device pixels for the same reason as the
+            // non-crop path in `update_transformation`: a half-pixel
+            // translation blurs the texture through bilinear sampling.
+            let offset_x = (pad_x - scale * crop_pos.x + self.drag_offset.x).round();
+            let offset_y = (pad_y - scale * crop_pos.y + self.drag_offset.y).round();
             // Visible-content canvas-pixel rect — used by the
             // drop-shadow path so the shadow falls around the
             // cropped region, not the full background image
@@ -2709,6 +2712,19 @@ impl FemtoVgAreaMut {
             //dragged
             self.offset = center_offset + Vec2D::new(effective_x, effective_y);
         }
+
+        // Snap the image origin to whole device pixels. `center_offset`
+        // is `(canvas − image) / 2`, which lands on a half-pixel
+        // whenever `canvas − image` is odd — and a half-pixel
+        // translation makes the GPU sample the background texture
+        // between texels, blurring the *entire* image through bilinear
+        // filtering even at an exact 1:1 scale. Rounding here keeps a
+        // 100%-zoom screenshot pixel-perfect; at a fractional render
+        // scale the image is resampled regardless, so the round is
+        // harmless. Drawables share this transform, so they stay
+        // pinned to the image.
+        self.offset.x = self.offset.x.round();
+        self.offset.y = self.offset.y.round();
     }
 
     /// Pan the canvas by `(dx, dy)` canvas-space pixels. Accumulates

--- a/src/femtovg_area/imp.rs
+++ b/src/femtovg_area/imp.rs
@@ -29,17 +29,10 @@ use crate::{
     tools::{CropTool, Drawable, DrawableId, Stacked, Tool, UndoAction},
 };
 
-use super::{font_stack, set_font_stack};
+use super::{CANVAS_PADDING_CSS, font_stack, set_font_stack};
 
 const TRANSPARENCY_SQUARE_SIZE: usize = 64;
 
-/// Breathing room (in CSS px) around the rendered screenshot inside
-/// the canvas. Gives the image visual separation from the toolbars
-/// and lets the drop shadow fall outside the image edges. Scaled to
-/// canvas pixels at render time via the device pixel ratio. Sized to
-/// fully contain the `SHADOW_KEY_*` extent below so the wide key
-/// shadow doesn't get clipped at the canvas edge.
-const CANVAS_PADDING_CSS: f32 = 60.0;
 /// Lowest auto-fit zoom a vertical window resize will shrink the
 /// image to. Enforced two ways so it holds under any window manager:
 /// `apply_vertical_resize_floor` pins a minimum height on `outer_box`

--- a/src/femtovg_area/mod.rs
+++ b/src/femtovg_area/mod.rs
@@ -21,6 +21,20 @@ use crate::{
     tools::{CropTool, Drawable, DrawableId, DrawableStore, Tool},
 };
 
+/// Breathing room (in CSS px) reserved on every side of the rendered
+/// screenshot inside the canvas. Gives the image visual separation
+/// from the toolbars and lets the drop shadow fall outside the image
+/// edges; sized to fully contain the key drop shadow so it isn't
+/// clipped at the canvas edge.
+///
+/// Single source of truth: the renderer pads the canvas by this much
+/// (`imp.rs`), and `main.rs` reserves the *same* amount when sizing
+/// the launch / crop-commit window — if the two disagree the image
+/// renders below 100% (the window is too small for the renderer's
+/// padding). Kept here, public, so a future user-facing padding
+/// setting has one constant to replace.
+pub const CANVAS_PADDING_CSS: f32 = 60.0;
+
 static FONT_STACK: OnceLock<Vec<FontId>> = OnceLock::new();
 
 pub fn set_font_stack(fonts: Vec<FontId>) {

--- a/src/main.rs
+++ b/src/main.rs
@@ -481,10 +481,14 @@ impl App {
         content_h: f64,
         monitor: Option<Rectangle>,
     ) -> (i32, i32) {
-        const IMAGE_PAD_CSS: f64 = 40.0;
+        // Reserve the SAME per-side padding the renderer pads the
+        // canvas with — if this is smaller the window is too small
+        // for the renderer's padding and the image renders below
+        // 100%. Single source of truth: `femtovg_area::CANVAS_PADDING_CSS`.
+        let image_pad = femtovg_area::CANVAS_PADDING_CSS as f64;
         const TOOLBAR_CHROME_CSS: f64 = 120.0;
-        let padded_w = content_w + 2.0 * IMAGE_PAD_CSS;
-        let padded_h = content_h + 2.0 * IMAGE_PAD_CSS + TOOLBAR_CHROME_CSS;
+        let padded_w = content_w + 2.0 * image_pad;
+        let padded_h = content_h + 2.0 * image_pad + TOOLBAR_CHROME_CSS;
         let (final_w, final_h) = if let Some(m) = monitor {
             let max_w = m.width() as f64 * 0.90;
             let max_h = m.height() as f64 * 0.90;
@@ -550,16 +554,18 @@ impl App {
         }
 
         let monitor_size_opt = Self::get_monitor_size(root);
-        // Padding around the image (matches CANVAS_PADDING_CSS in the
-        // renderer) + a generous estimate for the top/bottom toolbar
-        // chrome. The renderer scales the image to fit whatever canvas
-        // size GTK gives it, so an over-estimate just means a little
-        // extra breathing room — under-estimating causes the image to
-        // render at <100% even when it should fit at 1:1.
-        const IMAGE_PAD_CSS: f64 = 40.0;
+        // Padding around the image — the SAME per-side amount the
+        // renderer pads the canvas with (`femtovg_area::CANVAS_PADDING_CSS`,
+        // the single source of truth) — plus a generous estimate for
+        // the top/bottom toolbar chrome. The renderer scales the image
+        // to fit whatever canvas size GTK gives it, so an over-estimate
+        // just means a little extra breathing room — under-estimating
+        // causes the image to render at <100% even when it should fit
+        // at 1:1.
+        let image_pad = femtovg_area::CANVAS_PADDING_CSS as f64;
         const TOOLBAR_CHROME_CSS: f64 = 120.0;
-        let padded_image_w = image_width + 2.0 * IMAGE_PAD_CSS;
-        let padded_image_h = image_height + 2.0 * IMAGE_PAD_CSS + TOOLBAR_CHROME_CSS;
+        let padded_image_w = image_width + 2.0 * image_pad;
+        let padded_image_h = image_height + 2.0 * image_pad + TOOLBAR_CHROME_CSS;
 
         // Width floor so the top toolbar opens on a single row no
         // matter how narrow the image is. Measured live — the toolbar

--- a/src/main.rs
+++ b/src/main.rs
@@ -437,18 +437,13 @@ impl App {
         })
     }
 
-    /// Effective DPI scale to display dimensions in — divides capture-
-    /// native pixels into CSS-px equivalents so a 1498 × 218 image
-    /// taken on a 2× HiDPI screen reads as 749 × 109. Explicit
-    /// `input_scale` wins; otherwise we pick the larger of the
-    /// widget's `scale_factor()` and the monitor's `scale_factor()`
-    /// to handle Wayland fractional-scaling outputs where root can
-    /// report 1.
-    fn display_scale_divisor(root: &Window) -> i32 {
-        let input_scale = APP_CONFIG.read().input_scale();
-        if input_scale != 1.0 {
-            return input_scale.round().max(1.0) as i32;
-        }
+    /// Integer scale factor reported by GTK — the larger of the
+    /// window's and its monitor's `scale_factor()`. The monitor probe
+    /// handles Wayland fractional-scaling outputs where the root
+    /// surface can report `1`. Used only as the fallback when
+    /// `capture_scale` can't determine the real fractional scale
+    /// (non-Hyprland).
+    fn gtk_integer_scale(root: &Window) -> i32 {
         let root_scale = root.scale_factor().max(1);
         let monitor_scale = root
             .surface()
@@ -461,6 +456,18 @@ impl App {
             .unwrap_or(1)
             .max(1);
         root_scale.max(monitor_scale)
+    }
+
+    /// Fractional scale the screenshot was captured at — divides
+    /// capture-native pixels into logical ("1×") pixels so a
+    /// 1498 × 218 image taken on a 2× HiDPI screen reads as 749 × 109.
+    /// Prefers the real fractional scale (an `input_scale` override,
+    /// else the focused Hyprland monitor); falls back to GTK's integer
+    /// `scale_factor` off-Hyprland. Returns a non-integer on
+    /// fractional-scaling outputs (e.g. 1.07×), which GTK's own
+    /// `scale_factor()` rounds up to 2 and would halve the image.
+    fn capture_scale(root: &Window) -> f32 {
+        display::capture_scale().unwrap_or_else(|| Self::gtk_integer_scale(root) as f32)
     }
 
     /// Compute the window size to wrap `content_w × content_h` pixels
@@ -519,29 +526,14 @@ impl App {
 
         // Convert image dimensions from PIXELS (capture-native, what
         // grim hands us — device px on HiDPI displays) to the GTK
-        // window's CSS-px coordinate system. `input_scale` is the
-        // explicit user override; when it's left at the default 1.0
-        // we fall back to the widget's reported scale factor — and
-        // for Wayland fractional-scaling outputs (where GTK4 reports
-        // scale_factor=1 and relies on wp-fractional-scale) we also
-        // probe the monitor object for its scale.
-        let input_scale = APP_CONFIG.read().input_scale();
-        let root_scale = root.scale_factor().max(1) as f64;
-        let monitor_scale = root
-            .surface()
-            .and_then(|s| {
-                DisplayManager::get()
-                    .default_display()
-                    .and_then(|d| d.monitor_at_surface(&s))
-            })
-            .map(|m| m.scale_factor() as f64)
-            .unwrap_or(1.0)
-            .max(1.0);
-        let scale = if input_scale != 1.0 {
-            input_scale as f64
-        } else {
-            root_scale.max(monitor_scale)
-        };
+        // window's CSS-px coordinate system. `capture_scale` is the
+        // fractional scale the screenshot was taken at: an explicit
+        // `input_scale` override, else the focused Hyprland monitor's
+        // scale, else GTK's integer `scale_factor`. Using the
+        // fractional value matters on outputs like 1.07× — GTK's own
+        // `scale_factor()` rounds those to 2 and would size the
+        // window for a half-scale image.
+        let scale = Self::capture_scale(root) as f64;
         let image_width = self.image_dimensions.0 as f64 / scale;
         let image_height = self.image_dimensions.1 as f64 / scale;
 
@@ -961,15 +953,15 @@ impl Component for App {
             AppInput::DimensionsUpdate(dimensions) => {
                 let d = dimensions.unwrap_or(self.image_dimensions);
                 // Show the dimensions in the same coordinate system
-                // the user perceives — divide by the display's DPR
+                // the user perceives — divide by the capture scale
                 // so a 1498×218 image captured on a 2× HiDPI screen
                 // reads as 749×109 (the visual size of the region
                 // they framed), not the doubled device-pixel count.
-                let scale = Self::display_scale_divisor(root);
+                let scale = Self::capture_scale(root);
                 self.output_dimensions_label.set_text(&format!(
                     "{} x {}",
-                    d.0 / scale,
-                    d.1 / scale
+                    (d.0 as f32 / scale).round() as i32,
+                    (d.1 as f32 / scale).round() as i32
                 ));
                 // (NB: the crop-mode toolbar W/H entries get their
                 // live values via `CropEditDimensions` instead, so
@@ -1069,16 +1061,11 @@ impl Component for App {
             AppInput::ContentSizeChanged { width, height } => {
                 // Fit the window around the new content — applied via
                 // `set_default_size`, which Wayland's compositor will
-                // generally honor as a resize request. Same
-                // input_scale → device-pixel-ratio fallback as the
-                // initial-resize path: convert capture-native pixels
-                // into the window's CSS-px coord system.
-                let input_scale = APP_CONFIG.read().input_scale();
-                let scale = if input_scale != 1.0 {
-                    input_scale as f64
-                } else {
-                    root.scale_factor().max(1) as f64
-                };
+                // generally honor as a resize request. Uses the same
+                // fractional `capture_scale` as the initial-resize
+                // path to convert capture-native pixels into the
+                // window's CSS-px coord system.
+                let scale = Self::capture_scale(root) as f64;
                 let scaled_w = width as f64 / scale;
                 let scaled_h = height as f64 / scale;
                 let monitor = Self::get_monitor_size(root);
@@ -1597,14 +1584,14 @@ impl Component for App {
         // full image size so something's visible immediately —
         // sketch_board republishes via DimensionsUpdate whenever the
         // crop changes. Format must match the spaced "W x H" form
-        // used in the DimensionsUpdate handler above. Divide by DPR
-        // here too so the seeded value isn't doubled compared to
-        // what the user sees rendered on screen.
-        let display_scale = Self::display_scale_divisor(&root);
+        // used in the DimensionsUpdate handler above. Divide by the
+        // capture scale here too so the seeded value isn't doubled
+        // compared to what the user sees rendered on screen.
+        let display_scale = Self::capture_scale(&root);
         model.output_dimensions_label.set_text(&format!(
             "{} x {}",
-            image_dimensions.0 / display_scale,
-            image_dimensions.1 / display_scale,
+            (image_dimensions.0 as f32 / display_scale).round() as i32,
+            (image_dimensions.1 as f32 / display_scale).round() as i32,
         ));
 
         // Seed the ToolsToolbar's image_dimensions mirror so the

--- a/src/ui/toolbars.rs
+++ b/src/ui/toolbars.rs
@@ -58,6 +58,20 @@ thread_local! {
     static ACTIVE_TOOLTIP: RefCell<Option<gtk::Popover>> = const { RefCell::new(None) };
 }
 
+/// Divide raw image (capture-native) pixels by the fractional capture
+/// scale to get LOGICAL pixels — the size the user perceives on
+/// screen. Mirror of `image_px` below; both clamp the scale at 1.0 so
+/// a bogus sub-unity value can't invert the conversion.
+fn logical_px(image_px: i32, scale: f32) -> i32 {
+    (image_px as f32 / scale.max(1.0)).round() as i32
+}
+
+/// Multiply user-typed LOGICAL pixels back up to raw image pixels
+/// before they flow out as `ToolbarEvent`s.
+fn image_px(logical_px: i32, scale: f32) -> i32 {
+    (logical_px as f32 * scale.max(1.0)).round() as i32
+}
+
 fn show_tooltip(popover: &gtk::Popover) {
     ACTIVE_TOOLTIP.with(|active| {
         let mut active = active.borrow_mut();
@@ -240,18 +254,18 @@ pub struct ToolsToolbar {
     /// without taking `&mut self`. Updated by
     /// `ImageDimensionsChanged` / `SetDisplayScale`.
     resize_orig_dims: Option<std::rc::Rc<std::cell::Cell<(i32, i32)>>>,
-    resize_display_scale: Option<std::rc::Rc<std::cell::Cell<i32>>>,
+    resize_display_scale: Option<std::rc::Rc<std::cell::Cell<f32>>>,
     resize_aspect_locked: Option<std::rc::Rc<std::cell::Cell<bool>>>,
     resize_units: Option<std::rc::Rc<std::cell::Cell<ResizeUnits>>>,
-    /// Display device-pixel-ratio (matches main.rs's
-    /// `display_scale_divisor`). All user-facing pixel values
-    /// (crop W/H entries, "Image size: W × H px" label, resize
-    /// popover entries) divide raw image pixels by this to show
-    /// LOGICAL pixels — what the user sees on screen — and
-    /// multiply typed values back to image pixels before they
-    /// flow out as ToolbarEvents. Defaults to 1; main.rs pushes
+    /// Fractional capture scale (matches main.rs's `capture_scale`).
+    /// All user-facing pixel values (crop W/H entries, "Image size:
+    /// W × H px" label, resize popover entries) divide raw image
+    /// pixels by this to show LOGICAL pixels — what the user sees on
+    /// screen — and multiply typed values back to image pixels before
+    /// they flow out as ToolbarEvents. Non-integer on fractional-
+    /// scaling outputs (e.g. 1.07×). Defaults to 1.0; main.rs pushes
     /// the real value at startup via `SetDisplayScale`.
-    display_scale: i32,
+    display_scale: f32,
     /// Currently-selected color, mirrored on the unified color-picker
     /// MenuButton's swatch. Updated whenever a palette/custom color is
     /// chosen, so the swatch reflects what subsequent annotations will use.
@@ -2223,7 +2237,7 @@ pub enum ToolsToolbarInput {
     /// all user-facing pixel values (W/H entries, "Image size"
     /// label, resize-popover entries) render in LOGICAL pixels
     /// instead of raw image pixels.
-    SetDisplayScale(i32),
+    SetDisplayScale(f32),
     /// User clicked a dashed-empty placeholder in the saved-custom
     /// grid. Stash that slot index as `selected_empty_slot` so the
     /// next `SaveCustomColor` inserts at that visual position instead
@@ -3285,8 +3299,8 @@ impl Component for ToolsToolbar {
                         #[watch]
                         set_label: &format!(
                             "{} × {} px",
-                            model.image_width / model.display_scale.max(1),
-                            model.image_height / model.display_scale.max(1),
+                            logical_px(model.image_width, model.display_scale),
+                            logical_px(model.image_height, model.display_scale),
                         ),
                     },
                 },
@@ -3798,7 +3812,7 @@ impl Component for ToolsToolbar {
             ToolsToolbarInput::CropDimensionsChanged { width, height } => {
                 self.crop_width = width;
                 self.crop_height = height;
-                let s = self.display_scale.max(1);
+                let s = self.display_scale;
                 // Refresh the entries — but only when they don't
                 // currently have focus, so a user mid-typing in
                 // the W or H field doesn't see their text wiped
@@ -3809,23 +3823,23 @@ impl Component for ToolsToolbar {
                 if let Some(e) = &self.crop_width_entry
                     && !e.has_focus()
                 {
-                    e.set_text(&(width / s).to_string());
+                    e.set_text(&logical_px(width, s).to_string());
                 }
                 if let Some(e) = &self.crop_height_entry
                     && !e.has_focus()
                 {
-                    e.set_text(&(height / s).to_string());
+                    e.set_text(&logical_px(height, s).to_string());
                 }
             }
             ToolsToolbarInput::CropWidthEntered(value) => {
-                let s = self.display_scale.max(1);
+                let s = self.display_scale;
                 if let Some(w_logical) = value
                     && w_logical > 0
                 {
                     sender
                         .output_sender()
                         .emit(ToolbarEvent::CropDimensionsSet {
-                            width: w_logical * s,
+                            width: image_px(w_logical, s),
                             height: self.crop_height.max(1),
                         });
                     sender.output_sender().emit(ToolbarEvent::FocusCanvas);
@@ -3833,11 +3847,11 @@ impl Component for ToolsToolbar {
                     // Snap back to the last known good value so the
                     // entry doesn't keep showing unparseable text
                     // after Enter on (e.g.) empty input.
-                    e.set_text(&(self.crop_width / s).to_string());
+                    e.set_text(&logical_px(self.crop_width, s).to_string());
                 }
             }
             ToolsToolbarInput::CropHeightEntered(value) => {
-                let s = self.display_scale.max(1);
+                let s = self.display_scale;
                 if let Some(h_logical) = value
                     && h_logical > 0
                 {
@@ -3845,11 +3859,11 @@ impl Component for ToolsToolbar {
                         .output_sender()
                         .emit(ToolbarEvent::CropDimensionsSet {
                             width: self.crop_width.max(1),
-                            height: h_logical * s,
+                            height: image_px(h_logical, s),
                         });
                     sender.output_sender().emit(ToolbarEvent::FocusCanvas);
                 } else if let Some(e) = &self.crop_height_entry {
-                    e.set_text(&(self.crop_height / s).to_string());
+                    e.set_text(&logical_px(self.crop_height, s).to_string());
                 }
             }
             ToolsToolbarInput::CropDimensionsSwap => {
@@ -3886,7 +3900,7 @@ impl Component for ToolsToolbar {
             ToolsToolbarInput::ImageDimensionsChanged { width, height } => {
                 self.image_width = width;
                 self.image_height = height;
-                let s = self.display_scale.max(1);
+                let s = self.display_scale;
                 // Pre-populate the resize popover's entries so it
                 // opens already showing the current image dims in
                 // LOGICAL pixels. The popover only opens transiently
@@ -3894,10 +3908,10 @@ impl Component for ToolsToolbar {
                 // refresh these unconditionally without worrying
                 // about clobbering live typing.
                 if let Some(e) = &self.resize_width_entry {
-                    e.set_text(&(width / s).to_string());
+                    e.set_text(&logical_px(width, s).to_string());
                 }
                 if let Some(e) = &self.resize_height_entry {
-                    e.set_text(&(height / s).to_string());
+                    e.set_text(&logical_px(height, s).to_string());
                 }
                 // Mirror into the popover's shared state so
                 // aspect-lock + percent-mode math has the live
@@ -3907,7 +3921,7 @@ impl Component for ToolsToolbar {
                 }
             }
             ToolsToolbarInput::SetDisplayScale(scale) => {
-                self.display_scale = scale.max(1);
+                self.display_scale = scale.max(1.0);
                 // Refresh the entries with the new scale applied —
                 // covers the startup case where ImageDimensionsChanged
                 // fired before this scale was known, leaving the
@@ -3916,18 +3930,18 @@ impl Component for ToolsToolbar {
                 if let Some(e) = &self.crop_width_entry
                     && !e.has_focus()
                 {
-                    e.set_text(&(self.crop_width / s).to_string());
+                    e.set_text(&logical_px(self.crop_width, s).to_string());
                 }
                 if let Some(e) = &self.crop_height_entry
                     && !e.has_focus()
                 {
-                    e.set_text(&(self.crop_height / s).to_string());
+                    e.set_text(&logical_px(self.crop_height, s).to_string());
                 }
                 if let Some(e) = &self.resize_width_entry {
-                    e.set_text(&(self.image_width / s).to_string());
+                    e.set_text(&logical_px(self.image_width, s).to_string());
                 }
                 if let Some(e) = &self.resize_height_entry {
-                    e.set_text(&(self.image_height / s).to_string());
+                    e.set_text(&logical_px(self.image_height, s).to_string());
                 }
                 if let Some(d) = &self.resize_display_scale {
                     d.set(s);
@@ -4050,7 +4064,7 @@ impl Component for ToolsToolbar {
             crop_bg_color: crate::tools::CropBgColor::Auto,
             crop_bg_custom_swatch: None,
             crop_bg_custom_rgb: None,
-            display_scale: 1,
+            display_scale: 1.0,
             resize_orig_dims: None,
             resize_display_scale: None,
             resize_aspect_locked: None,
@@ -4115,7 +4129,7 @@ impl Component for ToolsToolbar {
             model.image_width.max(1),
             model.image_height.max(1),
         )));
-        let resize_display_scale_state = StdRc::new(StdCell::new(model.display_scale.max(1)));
+        let resize_display_scale_state = StdRc::new(StdCell::new(model.display_scale.max(1.0)));
         let resize_aspect_locked = StdRc::new(StdCell::new(false));
         let resize_units = StdRc::new(StdCell::new(ResizeUnits::Pixels));
 
@@ -4249,13 +4263,13 @@ impl Component for ToolsToolbar {
             };
             units_for_dd.set(new_units);
             let (orig_w, orig_h) = orig_for_dd.get();
-            let scale = scale_for_dd.get().max(1);
+            let scale = scale_for_dd.get();
             // Mute change handlers while we set programmatic text.
             syncing_for_dd.set(true);
             match new_units {
                 ResizeUnits::Pixels => {
-                    w_for_dd.set_text(&(orig_w / scale).to_string());
-                    h_for_dd.set_text(&(orig_h / scale).to_string());
+                    w_for_dd.set_text(&logical_px(orig_w, scale).to_string());
+                    h_for_dd.set_text(&logical_px(orig_h, scale).to_string());
                 }
                 ResizeUnits::Percent => {
                     w_for_dd.set_text("100");
@@ -4355,7 +4369,7 @@ impl Component for ToolsToolbar {
                 return;
             }
             let (orig_w, orig_h) = orig_for_resize.get();
-            let scale = scale_for_resize.get().max(1) as f32;
+            let scale = scale_for_resize.get().max(1.0);
             let (target_w_px, target_h_px) = match units_for_resize.get() {
                 ResizeUnits::Pixels => (
                     (w_val * scale).round() as i32,


### PR DESCRIPTION
## Summary

Fixes screenshots rendering at the wrong size and/or blurry, primarily on fractionally-scaled monitors. Three independent root causes, one per commit:

1. **`fix(scaling): render screenshots at true size on fractional-scale monitors`**
   On a fractionally-scaled output (e.g. a monitor at 1.07×) GTK's `scale_factor()` only reports the rounded-up integer (`2`), so window-sizing and canvas auto-fit divided the capture-native screenshot by 2 and it rendered at roughly half size. Adds `display::capture_scale()` (the real fractional scale — `input_scale` override → focused Hyprland monitor → GTK integer off-Hyprland) and threads it through window sizing, the dimensions label, the auto-fit `natural_scale` cap, and the zoom system. On integer-scaled displays `natural_scale` collapses to `1.0`, so the working 2× HiDPI path is untouched.

2. **`fix(scaling): unify canvas padding so region captures render at 100%`**
   The renderer padded the canvas by `CANVAS_PADDING_CSS` (60px) but `main.rs` only reserved 40px when sizing the window, so auto-fit shrank otherwise-fitting captures to ~95%. Promotes `CANVAS_PADDING_CSS` to a single public constant both sides read.

3. **`fix(scaling): snap image origin to whole pixels to avoid blur`**
   The canvas centred the image at `(canvas - image) / 2`, landing on a half-pixel when that difference was odd — a half-pixel translation makes the GPU sample the texture between texels, blurring the whole image even at exact 1:1 zoom. Rounds the image origin to whole device pixels.

All three are pre-existing bugs (2 and 3 predate the fractional-scale work; upstream Satty has them too).

## Test plan

- `cargo build` + `cargo test` clean (19 tests pass); each commit verified to build in isolation.
- Verified on a 2560×1600 monitor: at 1.15×/1.07× scale captures now render at true size; at integer scale 1.0 they render pixel-perfect (`scale_factor=1`, integer offset).
- Confirmed crisp on window, drag-region, and full-screen captures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)