### PR TITLE
feat: auto-install and wire the Omarchy screenshot wrapper

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -41,6 +41,7 @@ clean:
 
 install: target/release/tensaku
 	install -s -Dm755 target/release/tensaku -t $(BINDIR)
+	install -Dm755 assets/tensaku-edit $(BINDIR)/tensaku-edit
 	install -Dm644 dev.tensaku.Tensaku.desktop $(PREFIX)/share/applications/dev.tensaku.Tensaku.desktop
 	install -Dm644 assets/tensaku.svg $(PREFIX)/share/icons/hicolor/scalable/apps/dev.tensaku.Tensaku.svg
 	install -Dm644 LICENSE $(PREFIX)/share/licenses/tensaku/LICENSE
@@ -55,6 +56,7 @@ install: target/release/tensaku
 
 uninstall:
 	rm ${BINDIR}/tensaku
+	rm ${BINDIR}/tensaku-edit
 	rmdir -p ${PREFIX}/bin || true
 
 	rm ${PREFIX}/share/applications/dev.tensaku.Tensaku.desktop

--- a/README.md
+++ b/README.md
@@ -319,6 +319,10 @@ Options:
           Install the desktop entry and app icon into the user's XDG data directory (~/.local/share), then exit. Run this once after `cargo install tensaku`; package installs (AUR, make install) register these files already
       --doctor
           Report whether the optional external tools Tensaku relies on (grim, slurp, wl-copy) are installed and the session looks right, then exit
+      --install-omarchy-wrapper
+          Install the Omarchy screenshot wrapper (~/.local/bin/tensaku-edit) so Omarchy's screenshot keybinds open captures in Tensaku, then exit. Also checks that OMARCHY_SCREENSHOT_EDITOR points at it
+      --wire-omarchy
+          Point Omarchy's screenshot editor at the tensaku-edit wrapper: set OMARCHY_SCREENSHOT_EDITOR in ~/.config/hypr/envs.conf and in the running Hyprland session, then exit. Installs the wrapper first if needed; does not edit keybinds
   -c, --config <CONFIG>
           Path to the config file. Otherwise will be read from XDG_CONFIG_DIR/tensaku/config.toml
   -f, --filename <FILENAME>
@@ -426,21 +430,24 @@ Tensaku supports IME via GTK with and without preediting. Please note, at this p
 Omarchy already ships screenshot keybinds — they run
 `omarchy-capture-screenshot`, which handles the region/window selection
 and hands the capture to whatever `OMARCHY_SCREENSHOT_EDITOR` points at.
-Wire that to Tensaku.
+Tensaku takes its input as a flag, not a positional argument, so it needs
+a small wrapper (`~/.local/bin/tensaku-edit`) to bridge the two — and
+Tensaku manages that wrapper for you. It's installed automatically the
+first time Tensaku runs on an Omarchy session.
 
-Tensaku takes its input as a flag, not a positional argument, so add a
-small wrapper at `~/.local/bin/tensaku-edit`:
+To wire everything up in one step:
 
 ```sh
-#!/bin/bash
-exec tensaku --filename "$1" --output-filename "$1" \
-  --actions-on-enter save-to-clipboard --save-after-copy --copy-command wl-copy
+tensaku --wire-omarchy
 ```
 
-Make it executable, point `OMARCHY_SCREENSHOT_EDITOR` at the wrapper's
-absolute path (e.g. an `env =` line in `~/.config/hypr/envs.conf`), and
-run `hyprctl reload`. Your normal screenshot keys now open each capture
-straight into Tensaku — with Omarchy's window/output highlighting intact.
+This installs the wrapper if needed and points `OMARCHY_SCREENSHOT_EDITOR`
+at it — both in `~/.config/hypr/envs.conf` (persisted, and backed up first)
+and in the running Hyprland session, so your screenshot keys open each
+capture straight into Tensaku, with Omarchy's window/output highlighting
+intact and no restart needed. `tensaku --install-omarchy-wrapper` installs
+just the wrapper without touching any config, and `tensaku --doctor` shows
+the current wrapper and wiring status.
 
 **Scrolling capture** is a separate mode — `omarchy-capture-screenshot`
 doesn't cover it. Bind a key straight to `tensaku --scroll-capture`,

--- a/assets/tensaku-edit
+++ b/assets/tensaku-edit
@@ -1,0 +1,19 @@
+#!/bin/bash
+# Opens Tensaku to annotate a screenshot.
+#
+# Omarchy's screenshot scripts (omarchy-capture-screenshot,
+# screenshot-cursor) hand a single bare image path to whatever
+# $OMARCHY_SCREENSHOT_EDITOR names. Tensaku has no positional
+# filename argument, so this wrapper supplies the flags — matching
+# what Omarchy's built-in "satty" editor branch passes.
+#
+# `tensaku` is invoked by bare name so this works regardless of how
+# Tensaku was installed (~/.cargo/bin, /usr/bin, /usr/local/bin, …);
+# Omarchy's screenshot scripts run in the user session, where the
+# install dir is on $PATH.
+exec tensaku \
+  --filename "$1" \
+  --output-filename "$1" \
+  --actions-on-enter save-to-clipboard \
+  --save-after-copy \
+  --copy-command wl-copy

--- a/cli/src/command_line.rs
+++ b/cli/src/command_line.rs
@@ -26,6 +26,19 @@ pub struct CommandLine {
     #[arg(long, exclusive = true)]
     pub doctor: bool,
 
+    /// Install the Omarchy screenshot wrapper (~/.local/bin/tensaku-edit)
+    /// so Omarchy's screenshot keybinds open captures in Tensaku, then
+    /// exit. Also checks that OMARCHY_SCREENSHOT_EDITOR points at it.
+    #[arg(long, exclusive = true)]
+    pub install_omarchy_wrapper: bool,
+
+    /// Point Omarchy's screenshot editor at the tensaku-edit wrapper:
+    /// set OMARCHY_SCREENSHOT_EDITOR in ~/.config/hypr/envs.conf and in
+    /// the running Hyprland session, then exit. Installs the wrapper
+    /// first if needed; does not edit keybinds.
+    #[arg(long, exclusive = true)]
+    pub wire_omarchy: bool,
+
     /// Path to the config file. Otherwise will be read from XDG_CONFIG_DIR/tensaku/config.toml
     #[arg(short, long)]
     pub config: Option<String>,

--- a/packaging/aur-git/PKGBUILD
+++ b/packaging/aur-git/PKGBUILD
@@ -44,6 +44,7 @@ build() {
 package() {
   cd "$_pkgname"
   install -Dm755 target/release/tensaku "$pkgdir/usr/bin/tensaku"
+  install -Dm755 assets/tensaku-edit "$pkgdir/usr/bin/tensaku-edit"
   install -Dm644 dev.tensaku.Tensaku.desktop \
     "$pkgdir/usr/share/applications/dev.tensaku.Tensaku.desktop"
   install -Dm644 assets/tensaku.svg \

--- a/packaging/aur/PKGBUILD
+++ b/packaging/aur/PKGBUILD
@@ -33,6 +33,7 @@ build() {
 package() {
   cd "$pkgname-$pkgver"
   install -Dm755 target/release/tensaku "$pkgdir/usr/bin/tensaku"
+  install -Dm755 assets/tensaku-edit "$pkgdir/usr/bin/tensaku-edit"
   install -Dm644 dev.tensaku.Tensaku.desktop "$pkgdir/usr/share/applications/dev.tensaku.Tensaku.desktop"
   install -Dm644 assets/tensaku.svg "$pkgdir/usr/share/icons/hicolor/scalable/apps/dev.tensaku.Tensaku.svg"
   install -Dm644 man/tensaku.1 "$pkgdir/usr/share/man/man1/tensaku.1"

--- a/src/configuration.rs
+++ b/src/configuration.rs
@@ -42,6 +42,8 @@ pub struct Configuration {
     license: bool,
     install_desktop: bool,
     doctor: bool,
+    install_omarchy_wrapper: bool,
+    wire_omarchy: bool,
     input_filename: Option<String>,
     output_filename: Option<String>,
     fullscreen: Option<Fullscreen>,
@@ -546,6 +548,12 @@ impl Configuration {
         if command_line.doctor {
             self.doctor = true;
         }
+        if command_line.install_omarchy_wrapper {
+            self.install_omarchy_wrapper = true;
+        }
+        if command_line.wire_omarchy {
+            self.wire_omarchy = true;
+        }
         if command_line.early_exit {
             self.early_exit = command_line.early_exit;
         }
@@ -690,6 +698,14 @@ impl Configuration {
 
     pub fn doctor(&self) -> bool {
         self.doctor
+    }
+
+    pub fn install_omarchy_wrapper(&self) -> bool {
+        self.install_omarchy_wrapper
+    }
+
+    pub fn wire_omarchy(&self) -> bool {
+        self.wire_omarchy
     }
 
     pub fn early_exit(&self) -> bool {
@@ -949,6 +965,8 @@ impl Default for Configuration {
             license: false,
             install_desktop: false,
             doctor: false,
+            install_omarchy_wrapper: false,
+            wire_omarchy: false,
             input_filename: Some(String::new()),
             output_filename: None,
             fullscreen: None,

--- a/src/desktop_install.rs
+++ b/src/desktop_install.rs
@@ -26,7 +26,7 @@ const DESKTOP_ENTRY: &str = include_str!("../dev.tensaku.Tensaku.desktop");
 const APP_ID: &str = "dev.tensaku.Tensaku";
 
 /// `$XDG_DATA_HOME`, falling back to `$HOME/.local/share`.
-fn xdg_data_home() -> Result<PathBuf> {
+pub(crate) fn xdg_data_home() -> Result<PathBuf> {
     if let Some(dir) = std::env::var_os("XDG_DATA_HOME").filter(|d| !d.is_empty()) {
         return Ok(PathBuf::from(dir));
     }

--- a/src/doctor.rs
+++ b/src/doctor.rs
@@ -6,7 +6,7 @@
 use anyhow::Result;
 
 /// Is `bin` an executable file somewhere on `$PATH`?
-fn on_path(bin: &str) -> bool {
+pub(crate) fn on_path(bin: &str) -> bool {
     std::env::var_os("PATH")
         .map(|path| std::env::split_paths(&path).any(|dir| dir.join(bin).is_file()))
         .unwrap_or(false)
@@ -56,6 +56,11 @@ pub fn run() -> Result<()> {
             println!("          {}", c.hint);
         }
     }
+
+    if crate::omarchy_wrapper::is_omarchy() {
+        report_omarchy_wrapper();
+    }
+
     println!();
     if missing == 0 {
         println!("All good — every tool Tensaku's workflow uses is present.");
@@ -63,4 +68,45 @@ pub fn run() -> Result<()> {
         println!("{missing} missing. Tensaku still runs, but the noted features won't work.");
     }
     Ok(())
+}
+
+/// On Omarchy, report whether the screenshot wrapper is installed and
+/// whether `$OMARCHY_SCREENSHOT_EDITOR` is wired to it.
+fn report_omarchy_wrapper() {
+    use crate::omarchy_wrapper::{Wiring, classify_wiring, wrapper_path};
+
+    println!();
+    println!("Omarchy detected — screenshot wrapper:");
+
+    let wrapper = match wrapper_path() {
+        Ok(p) => p,
+        Err(_) => {
+            println!("  [miss]  can't locate ~/.local/bin (is $HOME set?)");
+            return;
+        }
+    };
+
+    if wrapper.exists() {
+        println!("  [ ok ]  wrapper installed: {}", wrapper.display());
+    } else {
+        println!("  [miss]  wrapper not installed: {}", wrapper.display());
+        println!("          run: tensaku --install-omarchy-wrapper");
+    }
+
+    match classify_wiring(std::env::var_os("OMARCHY_SCREENSHOT_EDITOR"), &wrapper) {
+        Wiring::Correct => {
+            println!("  [ ok ]  OMARCHY_SCREENSHOT_EDITOR points at the wrapper");
+        }
+        Wiring::Elsewhere(other) => {
+            println!(
+                "  [miss]  OMARCHY_SCREENSHOT_EDITOR points at {}",
+                other.display()
+            );
+            println!("          point it at the wrapper, then run: hyprctl reload");
+        }
+        Wiring::Unset => {
+            println!("  [miss]  OMARCHY_SCREENSHOT_EDITOR is not set");
+            println!("          point it at the wrapper, then run: hyprctl reload");
+        }
+    }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -40,6 +40,7 @@ mod icons;
 mod ime;
 mod math;
 mod notification;
+mod omarchy_wrapper;
 mod scroll_capture;
 mod sketch_board;
 mod state;
@@ -1843,6 +1844,12 @@ fn main() -> Result<()> {
     if APP_CONFIG.read().doctor() {
         return doctor::run();
     }
+    if APP_CONFIG.read().install_omarchy_wrapper() {
+        return omarchy_wrapper::run();
+    }
+    if APP_CONFIG.read().wire_omarchy() {
+        return omarchy_wrapper::wire();
+    }
     if APP_CONFIG.read().profile_startup() {
         eprintln!(
             "startup timestamp was {}",
@@ -1856,6 +1863,12 @@ fn main() -> Result<()> {
     // Do it silently on the first normal launch — best-effort, never
     // blocks startup. --install-desktop stays the explicit, verbose path.
     desktop_install::ensure_first_launch();
+
+    // First-launch Omarchy wrapper: on an Omarchy session, place
+    // ~/.local/bin/tensaku-edit so the screenshot keybinds open captures
+    // in Tensaku. Silent, one-shot, best-effort; --install-omarchy-wrapper
+    // stays the explicit, verbose path.
+    omarchy_wrapper::ensure_first_launch();
 
     if APP_CONFIG.read().scroll_capture() {
         return match scroll_capture::run() {

--- a/src/omarchy_wrapper.rs
+++ b/src/omarchy_wrapper.rs
@@ -1,0 +1,610 @@
+//! Omarchy screenshot-wrapper integration.
+//!
+//! Omarchy's screenshot keybinds run `omarchy-capture-screenshot`, which
+//! hands the captured image path to whatever `$OMARCHY_SCREENSHOT_EDITOR`
+//! names. Tensaku takes its input as a flag, not a positional argument,
+//! so a small wrapper at `~/.local/bin/tensaku-edit` adapts the call.
+//! This module places that wrapper so a fresh Omarchy install needs no
+//! manual setup. It runs two ways, mirroring [`crate::desktop_install`]:
+//!
+//! - [`run`] — the explicit `--install-omarchy-wrapper` flag; installs,
+//!   then reports and verifies the `$OMARCHY_SCREENSHOT_EDITOR` wiring.
+//! - [`ensure_first_launch`] — silent and one-shot, on the first normal
+//!   launch, when Omarchy is detected.
+//!
+//! It never edits Omarchy or Hyprland config: pointing
+//! `$OMARCHY_SCREENSHOT_EDITOR` at the wrapper stays the user's (or
+//! Omarchy's own default) job. The verbose paths only *warn* when it
+//! isn't pointed here.
+
+use std::ffi::{OsStr, OsString};
+use std::os::unix::fs::PermissionsExt;
+use std::path::{Path, PathBuf};
+
+use anyhow::{Context, Result};
+use xdg::BaseDirectories;
+
+use crate::desktop_install::xdg_data_home;
+use crate::doctor::on_path;
+
+/// The wrapper script, embedded so the install works from a `cargo
+/// install`ed binary with no repo checkout present.
+const WRAPPER: &str = include_str!("../assets/tensaku-edit");
+
+/// Basename of the wrapper Omarchy is wired to invoke.
+const WRAPPER_NAME: &str = "tensaku-edit";
+
+/// Is this an Omarchy session? `$OMARCHY_PATH` is the canonical signal
+/// Omarchy exports; the data-dir check is a fallback for a shell that
+/// didn't inherit it.
+pub(crate) fn is_omarchy() -> bool {
+    let data_home = xdg_data_home().ok();
+    is_omarchy_with(
+        std::env::var_os("OMARCHY_PATH").as_deref(),
+        data_home.as_deref(),
+    )
+}
+
+/// Pure core of [`is_omarchy`], split out so it can be unit-tested
+/// without mutating the process environment.
+fn is_omarchy_with(omarchy_path: Option<&OsStr>, data_home: Option<&Path>) -> bool {
+    omarchy_path.is_some_and(|p| !p.is_empty())
+        || data_home.is_some_and(|d| d.join("omarchy").is_dir())
+}
+
+/// `~/.local/bin/tensaku-edit` — where Omarchy expects the editor
+/// wrapper to live.
+pub(crate) fn wrapper_path() -> Result<PathBuf> {
+    let home = std::env::var_os("HOME").context("HOME is not set")?;
+    Ok(PathBuf::from(home).join(".local/bin").join(WRAPPER_NAME))
+}
+
+/// Write the wrapper and mark it executable. Returns its path.
+fn install() -> Result<PathBuf> {
+    let path = wrapper_path()?;
+    let dir = path.parent().expect("wrapper path always has a parent");
+    std::fs::create_dir_all(dir).with_context(|| format!("create {}", dir.display()))?;
+    std::fs::write(&path, WRAPPER).with_context(|| format!("write {}", path.display()))?;
+    std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o755))
+        .with_context(|| format!("chmod {}", path.display()))?;
+    Ok(path)
+}
+
+/// How `$OMARCHY_SCREENSHOT_EDITOR` relates to our wrapper.
+#[derive(Debug, PartialEq, Eq)]
+pub(crate) enum Wiring {
+    /// Points at our wrapper — captures will open in Tensaku.
+    Correct,
+    /// Set, but to some other editor (carried for the warning message).
+    Elsewhere(PathBuf),
+    /// Not set at all.
+    Unset,
+}
+
+/// Classify `$OMARCHY_SCREENSHOT_EDITOR` against `wrapper`. Pure (takes
+/// the env value as an argument) so it can be unit-tested, and total: it
+/// always returns a classification, never an error.
+///
+/// The value may be unset, carry trailing arguments, use a leading `~/`,
+/// or name a path that doesn't exist yet — so we compare the first
+/// whitespace token, expand a leading tilde, and fall back to plain path
+/// equality when `canonicalize` can't resolve a (possibly missing) path.
+pub(crate) fn classify_wiring(env_val: Option<OsString>, wrapper: &Path) -> Wiring {
+    let raw = match env_val {
+        Some(v) if !v.is_empty() => v,
+        _ => return Wiring::Unset,
+    };
+    let value = raw.to_string_lossy();
+    let Some(first) = value.split_whitespace().next() else {
+        return Wiring::Unset;
+    };
+
+    // Env vars aren't tilde-expanded the way a shell expands them, so
+    // handle a literal leading `~/` ourselves.
+    let candidate = match first.strip_prefix("~/") {
+        Some(rest) => match std::env::var_os("HOME") {
+            Some(home) => PathBuf::from(home).join(rest),
+            None => PathBuf::from(first),
+        },
+        None => PathBuf::from(first),
+    };
+
+    let same = match (
+        std::fs::canonicalize(&candidate).ok(),
+        std::fs::canonicalize(wrapper).ok(),
+    ) {
+        (Some(a), Some(b)) => a == b,
+        // One or both paths don't exist yet — compare as written.
+        _ => candidate == wrapper,
+    };
+
+    if same {
+        Wiring::Correct
+    } else {
+        Wiring::Elsewhere(candidate)
+    }
+}
+
+/// Print the steps to point `$OMARCHY_SCREENSHOT_EDITOR` at the wrapper.
+fn print_wiring_help(wrapper: &Path) {
+    println!("Point it at the wrapper to open captures in Tensaku — add to");
+    println!("~/.config/hypr/envs.conf:");
+    println!("  env = OMARCHY_SCREENSHOT_EDITOR,{}", wrapper.display());
+    println!("then run: hyprctl reload");
+}
+
+/// `--install-omarchy-wrapper`: install the wrapper and report what
+/// landed, then check the `$OMARCHY_SCREENSHOT_EDITOR` wiring.
+pub fn run() -> Result<()> {
+    let path = wrapper_path()?;
+    let existed = path.exists();
+    install()?;
+
+    if existed {
+        println!("Updated Omarchy screenshot wrapper (overwrote existing):");
+    } else {
+        println!("Installed Omarchy screenshot wrapper:");
+    }
+    println!("  {}", path.display());
+    println!();
+
+    if !is_omarchy() {
+        println!(
+            "Note: this doesn't look like an Omarchy session ($OMARCHY_PATH unset and no\n\
+             ~/.local/share/omarchy). The wrapper is installed anyway."
+        );
+        println!();
+    }
+
+    match classify_wiring(std::env::var_os("OMARCHY_SCREENSHOT_EDITOR"), &path) {
+        Wiring::Correct => {
+            println!("OMARCHY_SCREENSHOT_EDITOR already points at the wrapper — you're set.");
+        }
+        Wiring::Elsewhere(other) => {
+            println!(
+                "OMARCHY_SCREENSHOT_EDITOR points at {}, not the Tensaku wrapper.",
+                other.display()
+            );
+            print_wiring_help(&path);
+        }
+        Wiring::Unset => {
+            println!("OMARCHY_SCREENSHOT_EDITOR is not set.");
+            print_wiring_help(&path);
+        }
+    }
+
+    if !on_path("tensaku") {
+        println!();
+        println!("Warning: `tensaku` isn't on $PATH, so the wrapper's `exec tensaku` will");
+        println!("fail when Omarchy invokes it. Put Tensaku's install dir on $PATH.");
+    }
+
+    Ok(())
+}
+
+/// Install the wrapper silently on the first normal launch, when Omarchy
+/// is detected, so a fresh Omarchy setup needs no manual step.
+///
+/// One-shot via a marker in the XDG state dir, and silent: this runs
+/// during a GUI launch, so the verbose `--install-omarchy-wrapper` path
+/// is where the wiring is reported. Best-effort throughout — wrapper
+/// housekeeping must never break startup, so any failure is swallowed
+/// (and left to retry next launch). Skips Flatpak (sandboxed) and never
+/// overwrites a wrapper the user already has.
+pub fn ensure_first_launch() {
+    let _ = try_ensure_first_launch();
+}
+
+fn try_ensure_first_launch() -> Result<()> {
+    // Sandboxed: ~/.local/bin isn't meaningful inside a Flatpak.
+    if std::env::var_os("FLATPAK_ID").is_some() {
+        return Ok(());
+    }
+
+    // Only auto-install on Omarchy — anywhere else the wrapper is inert.
+    if !is_omarchy() {
+        return Ok(());
+    }
+
+    // The marker means the one-time first-launch step is already done.
+    // `place_state_file` also creates the state dir for the write below.
+    let marker = BaseDirectories::with_prefix(env!("CARGO_PKG_NAME"))
+        .place_state_file("omarchy-wrapper-done")
+        .context("locate the XDG state dir")?;
+    if marker.exists() {
+        return Ok(());
+    }
+
+    // Never clobber a wrapper the user (or a previous run) already placed,
+    // and skip when a packaged wrapper (e.g. /usr/bin/tensaku-edit) already
+    // provides it — a per-user copy would only shadow the system one.
+    // --install-omarchy-wrapper is the explicit path for a reset.
+    if !wrapper_path()?.exists() && !packaged_wrapper_exists() {
+        install()?;
+    }
+
+    // Record completion last, so a failed install above is retried on the
+    // next launch rather than marked done.
+    std::fs::write(
+        &marker,
+        "Tensaku ran its one-time first-launch Omarchy wrapper install.\n",
+    )
+    .with_context(|| format!("write {}", marker.display()))?;
+    Ok(())
+}
+
+/// Find an executable named `bin` on `$PATH`, returning its full path.
+fn which(bin: &str) -> Option<PathBuf> {
+    let path = std::env::var_os("PATH")?;
+    std::env::split_paths(&path)
+        .map(|dir| dir.join(bin))
+        .find(|p| p.is_file())
+}
+
+/// The wrapper path to wire `$OMARCHY_SCREENSHOT_EDITOR` at: a packaged
+/// `tensaku-edit` on `$PATH` (e.g. `/usr/bin/tensaku-edit`) wins; otherwise
+/// ensure the per-user copy exists and use that. Wiring at a missing file
+/// would be pointless, so this never returns a path that doesn't exist.
+fn find_or_install_wrapper() -> Result<PathBuf> {
+    if let Some(p) = which(WRAPPER_NAME) {
+        return Ok(p);
+    }
+    let p = wrapper_path()?;
+    if !p.exists() {
+        install()?;
+    }
+    Ok(p)
+}
+
+/// Does a system install already provide the wrapper? A package (AUR /
+/// `make install`) drops `tensaku-edit` into a system bindir on `$PATH`
+/// (e.g. `/usr/bin`); a user-local copy would only shadow it. True when a
+/// `tensaku-edit` on `$PATH` resolves to something other than our per-user
+/// path.
+fn packaged_wrapper_exists() -> bool {
+    match (which(WRAPPER_NAME), wrapper_path()) {
+        (Some(found), Ok(ours)) => found != ours,
+        (Some(_), Err(_)) => true,
+        _ => false,
+    }
+}
+
+/// `$XDG_CONFIG_HOME/hypr/envs.conf`, falling back to `~/.config/...`.
+fn hypr_envs_conf() -> Result<PathBuf> {
+    let base = if let Some(dir) = std::env::var_os("XDG_CONFIG_HOME").filter(|d| !d.is_empty()) {
+        PathBuf::from(dir)
+    } else {
+        let home = std::env::var_os("HOME").context("HOME is not set")?;
+        PathBuf::from(home).join(".config")
+    };
+    Ok(base.join("hypr").join("envs.conf"))
+}
+
+/// Sibling `bindings.conf`, used only to detect conflicting inline binds.
+fn hypr_bindings_conf() -> Result<PathBuf> {
+    Ok(hypr_envs_conf()?.with_file_name("bindings.conf"))
+}
+
+/// The canonical Hyprland env directive wiring the screenshot editor.
+fn desired_env_line(wrapper: &str) -> String {
+    format!("env = OMARCHY_SCREENSHOT_EDITOR,{wrapper}")
+}
+
+/// If `line` is an `env = OMARCHY_SCREENSHOT_EDITOR,<value>` directive,
+/// return its `<value>` (trimmed). Comments (`#…`) don't match because
+/// they don't start with `env`.
+fn env_line_value(line: &str) -> Option<String> {
+    let rest = line.trim().strip_prefix("env")?.trim_start();
+    let rest = rest.strip_prefix('=')?.trim_start();
+    let rest = rest.strip_prefix("OMARCHY_SCREENSHOT_EDITOR")?.trim_start();
+    let value = rest.strip_prefix(',')?.trim();
+    Some(value.to_string())
+}
+
+/// An inline `env OMARCHY_SCREENSHOT_EDITOR=<value>` prefix on an `exec`
+/// bind, returned as `<value>`. This is the per-command form (NAME=value),
+/// distinct from the envs.conf directive form (NAME,value).
+fn inline_bind_editor_value(line: &str) -> Option<String> {
+    let marker = "OMARCHY_SCREENSHOT_EDITOR=";
+    let after = &line[line.find(marker)? + marker.len()..];
+    match after.split_whitespace().next() {
+        Some(v) if !v.is_empty() => Some(v.to_string()),
+        _ => None,
+    }
+}
+
+/// Outcome of reconciling envs.conf with the desired wiring.
+#[derive(Debug, PartialEq, Eq)]
+enum EnvLineOutcome {
+    /// The correct line is already present — nothing to write.
+    AlreadySet,
+    /// An existing line pointed elsewhere and was rewritten.
+    Updated(String),
+    /// No line existed; one was appended.
+    Inserted(String),
+}
+
+/// Reconcile `contents` (an envs.conf) with the desired wiring. Pure, so
+/// the line-rewriting rules can be unit-tested without touching the disk.
+fn apply_env_line(contents: &str, wrapper: &str) -> EnvLineOutcome {
+    let desired = desired_env_line(wrapper);
+    let mut lines: Vec<String> = contents.lines().map(str::to_string).collect();
+
+    if let Some(idx) = lines.iter().position(|l| env_line_value(l).is_some()) {
+        if env_line_value(&lines[idx]).as_deref() == Some(wrapper) {
+            return EnvLineOutcome::AlreadySet;
+        }
+        lines[idx] = desired;
+        let mut out = lines.join("\n");
+        if contents.ends_with('\n') {
+            out.push('\n');
+        }
+        EnvLineOutcome::Updated(out)
+    } else {
+        let mut out = contents.to_string();
+        if !out.is_empty() && !out.ends_with('\n') {
+            out.push('\n');
+        }
+        if !out.is_empty() {
+            out.push('\n');
+        }
+        out.push_str("# Tensaku screenshot editor (set by `tensaku --wire-omarchy`).\n");
+        out.push_str(&desired);
+        out.push('\n');
+        EnvLineOutcome::Inserted(out)
+    }
+}
+
+/// `<path>.bak.<unix-seconds>`, matching Omarchy's backup convention.
+fn backup_path(file: &Path) -> PathBuf {
+    let secs = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_secs())
+        .unwrap_or(0);
+    let name = file
+        .file_name()
+        .map(|n| n.to_string_lossy().into_owned())
+        .unwrap_or_default();
+    file.with_file_name(format!("{name}.bak.{secs}"))
+}
+
+/// Set the var in the running Hyprland session via `hyprctl keyword env`,
+/// which propagates to processes Hyprland spawns afterward. No-op (with a
+/// note) when not in a Hyprland session or `hyprctl` is unavailable.
+fn apply_live(wrapper: &str) {
+    if std::env::var_os("HYPRLAND_INSTANCE_SIGNATURE").is_none() || which("hyprctl").is_none() {
+        println!("(not in a Hyprland session — this takes effect on next Hyprland start.)");
+        return;
+    }
+    // `.output()` (not `.status()`) so hyprctl's own "ok" doesn't leak
+    // into our report.
+    let ok = std::process::Command::new("hyprctl")
+        .arg("keyword")
+        .arg("env")
+        .arg(format!("OMARCHY_SCREENSHOT_EDITOR,{wrapper}"))
+        .output()
+        .map(|o| o.status.success())
+        .unwrap_or(false);
+    if ok {
+        println!("Applied to the running Hyprland session (effective immediately).");
+    } else {
+        println!("(couldn't apply live via hyprctl — takes effect on next Hyprland start.)");
+    }
+}
+
+/// Warn if a screenshot bind sets `OMARCHY_SCREENSHOT_EDITOR` inline to
+/// something other than `wrapper`: such a prefix overrides both envs.conf
+/// and the live env, so the wiring wouldn't take effect for that bind. We
+/// don't edit bindings.conf (by design) — just flag it.
+fn warn_conflicting_binds(wrapper: &str) {
+    let Ok(path) = hypr_bindings_conf() else {
+        return;
+    };
+    let Ok(contents) = std::fs::read_to_string(&path) else {
+        return;
+    };
+    let conflicts: Vec<String> = contents
+        .lines()
+        .filter(|l| !l.trim_start().starts_with('#'))
+        .filter_map(inline_bind_editor_value)
+        .filter(|v| v != wrapper)
+        .collect();
+    if let Some(first) = conflicts.first() {
+        println!();
+        println!(
+            "Warning: {} screenshot bind(s) in {} set OMARCHY_SCREENSHOT_EDITOR inline",
+            conflicts.len(),
+            path.display()
+        );
+        println!("(e.g. → {first}), which overrides what was just set. Remove the inline");
+        println!("`env OMARCHY_SCREENSHOT_EDITOR=…` prefix from those binds for it to apply.");
+    }
+}
+
+/// `--wire-omarchy`: point `$OMARCHY_SCREENSHOT_EDITOR` at the wrapper —
+/// persistently in Hyprland's envs.conf, and live in the running session.
+/// Ensures the wrapper exists first; never edits keybinds.
+pub fn wire() -> Result<()> {
+    let wrapper = find_or_install_wrapper()?;
+    let wrapper_str = wrapper.to_string_lossy().into_owned();
+
+    let envs = hypr_envs_conf()?;
+    let existing = std::fs::read_to_string(&envs).unwrap_or_default();
+    match apply_env_line(&existing, &wrapper_str) {
+        EnvLineOutcome::AlreadySet => {
+            println!("envs.conf already wires OMARCHY_SCREENSHOT_EDITOR → {wrapper_str}");
+        }
+        EnvLineOutcome::Updated(new) | EnvLineOutcome::Inserted(new) => {
+            if envs.exists() {
+                let backup = backup_path(&envs);
+                std::fs::copy(&envs, &backup)
+                    .with_context(|| format!("back up {}", envs.display()))?;
+                println!("Backed up {} → {}", envs.display(), backup.display());
+            } else if let Some(dir) = envs.parent() {
+                std::fs::create_dir_all(dir)
+                    .with_context(|| format!("create {}", dir.display()))?;
+            }
+            std::fs::write(&envs, new).with_context(|| format!("write {}", envs.display()))?;
+            println!(
+                "Set OMARCHY_SCREENSHOT_EDITOR → {wrapper_str}\n  in {}",
+                envs.display()
+            );
+        }
+    }
+
+    apply_live(&wrapper_str);
+    warn_conflicting_binds(&wrapper_str);
+
+    println!();
+    println!("Done — your screenshot keys will open captures in Tensaku.");
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn env_line_value_parses_variants() {
+        assert_eq!(
+            env_line_value("env = OMARCHY_SCREENSHOT_EDITOR,/usr/bin/tensaku-edit").as_deref(),
+            Some("/usr/bin/tensaku-edit")
+        );
+        // No spaces around '='.
+        assert_eq!(
+            env_line_value("env=OMARCHY_SCREENSHOT_EDITOR,/x").as_deref(),
+            Some("/x")
+        );
+        // Leading indentation and trailing space tolerated.
+        assert_eq!(
+            env_line_value("   env = OMARCHY_SCREENSHOT_EDITOR,/x  ").as_deref(),
+            Some("/x")
+        );
+        // Comments and other vars don't match.
+        assert!(env_line_value("# env = OMARCHY_SCREENSHOT_EDITOR,/x").is_none());
+        assert!(env_line_value("env = SOMETHING_ELSE,/x").is_none());
+    }
+
+    #[test]
+    fn apply_env_line_inserts_when_absent() {
+        match apply_env_line("# Extra env variables\n", "/usr/bin/tensaku-edit") {
+            EnvLineOutcome::Inserted(s) => {
+                assert!(s.contains("env = OMARCHY_SCREENSHOT_EDITOR,/usr/bin/tensaku-edit"));
+                assert!(s.starts_with("# Extra env variables\n"));
+            }
+            other => panic!("expected Inserted, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn apply_env_line_already_set_is_noop() {
+        let contents = "env = OMARCHY_SCREENSHOT_EDITOR,/usr/bin/tensaku-edit\n";
+        assert_eq!(
+            apply_env_line(contents, "/usr/bin/tensaku-edit"),
+            EnvLineOutcome::AlreadySet
+        );
+    }
+
+    #[test]
+    fn apply_env_line_updates_when_different() {
+        let contents = "a\nenv = OMARCHY_SCREENSHOT_EDITOR,/old/path\nb\n";
+        match apply_env_line(contents, "/usr/bin/tensaku-edit") {
+            EnvLineOutcome::Updated(s) => {
+                assert!(s.contains("env = OMARCHY_SCREENSHOT_EDITOR,/usr/bin/tensaku-edit"));
+                assert!(!s.contains("/old/path"));
+                assert!(s.starts_with("a\n") && s.trim_end().ends_with('b'));
+            }
+            other => panic!("expected Updated, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn inline_bind_value_extraction() {
+        let bind = "bindd = , code:191, Screenshot, exec, env OMARCHY_SCREENSHOT_EDITOR=/home/u/.local/bin/tensaku-edit omarchy-capture-screenshot";
+        assert_eq!(
+            inline_bind_editor_value(bind).as_deref(),
+            Some("/home/u/.local/bin/tensaku-edit")
+        );
+        // The envs.conf comma form is not an inline bind value.
+        assert!(inline_bind_editor_value("env = OMARCHY_SCREENSHOT_EDITOR,/x").is_none());
+    }
+
+    #[test]
+    fn omarchy_detected_via_env() {
+        // A non-empty $OMARCHY_PATH is sufficient, regardless of dirs.
+        assert!(is_omarchy_with(
+            Some(OsStr::new("/home/u/.local/share/omarchy")),
+            Some(Path::new("/zzz-no-such-data-home")),
+        ));
+    }
+
+    #[test]
+    fn omarchy_absent_when_no_signal() {
+        // Empty env value doesn't count; missing dir doesn't count.
+        assert!(!is_omarchy_with(
+            Some(OsStr::new("")),
+            Some(Path::new("/zzz-no-such-data-home")),
+        ));
+        assert!(!is_omarchy_with(
+            None,
+            Some(Path::new("/zzz-no-such-data-home"))
+        ));
+        assert!(!is_omarchy_with(None, None));
+    }
+
+    #[test]
+    fn wiring_unset() {
+        let w = PathBuf::from("/zzz/.local/bin/tensaku-edit");
+        assert_eq!(classify_wiring(None, &w), Wiring::Unset);
+        assert_eq!(classify_wiring(Some(OsString::new()), &w), Wiring::Unset);
+        // All-whitespace value has no token.
+        assert_eq!(
+            classify_wiring(Some(OsString::from("   ")), &w),
+            Wiring::Unset
+        );
+    }
+
+    #[test]
+    fn wiring_correct_exact_match() {
+        // Fake path: canonicalize fails for both, so it falls back to
+        // plain equality, which matches.
+        let w = PathBuf::from("/zzz/.local/bin/tensaku-edit");
+        assert_eq!(
+            classify_wiring(Some(OsString::from("/zzz/.local/bin/tensaku-edit")), &w),
+            Wiring::Correct,
+        );
+    }
+
+    #[test]
+    fn wiring_elsewhere_keeps_the_other_path() {
+        let w = PathBuf::from("/zzz/.local/bin/tensaku-edit");
+        assert_eq!(
+            classify_wiring(Some(OsString::from("/usr/bin/satty")), &w),
+            Wiring::Elsewhere(PathBuf::from("/usr/bin/satty")),
+        );
+    }
+
+    #[test]
+    fn wiring_ignores_trailing_args() {
+        let w = PathBuf::from("/zzz/.local/bin/tensaku-edit");
+        assert_eq!(
+            classify_wiring(
+                Some(OsString::from("/zzz/.local/bin/tensaku-edit --foo bar")),
+                &w,
+            ),
+            Wiring::Correct,
+        );
+    }
+
+    #[test]
+    fn wiring_expands_leading_tilde() {
+        // Build the wrapper from $HOME so the tilde-expanded candidate
+        // resolves to the same path.
+        let home = std::env::var_os("HOME").expect("HOME set in test env");
+        let w = PathBuf::from(&home).join(".local/bin/tensaku-edit");
+        assert_eq!(
+            classify_wiring(Some(OsString::from("~/.local/bin/tensaku-edit")), &w),
+            Wiring::Correct,
+        );
+    }
+}


### PR DESCRIPTION
## What

Make the Omarchy screenshot integration zero-touch: Tensaku installs and wires its `tensaku-edit` wrapper itself.

Omarchy's screenshot keybinds run `omarchy-capture-screenshot`, which hands a bare image path to `$OMARCHY_SCREENSHOT_EDITOR`. Tensaku takes input via flags, so it needs a small wrapper to bridge the two. Previously users had to create and wire that wrapper by hand.

## Changes

**Wrapper install**
- New `assets/tensaku-edit` (embedded) and `src/omarchy_wrapper.rs`.
- First-launch auto-install on Omarchy — silent, one-shot, state-marker guarded, best-effort (mirrors `desktop_install`).
- `--install-omarchy-wrapper` for an explicit (re)install.

**Wiring**
- `--wire-omarchy`: sets `OMARCHY_SCREENSHOT_EDITOR` persistently in `~/.config/hypr/envs.conf` (backed up, idempotent) **and** live via `hyprctl keyword env`. Doesn't touch keybinds; warns if a screenshot bind carries a conflicting inline `env …=` prefix.

**Discovery**
- `--doctor` shows wrapper + wiring status on Omarchy.

**Packaging**
- `make install` and the AUR PKGBUILDs (`aur`, `aur-git`, and `aur-bin` via the staged tarball) now ship `/usr/bin/tensaku-edit`, so a fresh package install needs no command. First-launch skips the per-user copy when a packaged wrapper is already on `$PATH`.

**Docs**
- README Omarchy section rewritten around the automated flow; by-hand wrapper instructions removed; `--help` block regenerated.

## Design notes
- The wrapper execs `tensaku` by **bare name** so it works regardless of install method (`~/.cargo/bin`, `/usr/bin`, `/usr/local/bin`).
- `hyprctl setenv` doesn't exist in current Hyprland; `hyprctl keyword env NAME,value` is used and verified to propagate to processes Hyprland spawns afterward.

## Testing
- `cargo fmt`, `clippy -D warnings`, `cargo test` — 31 pass, including new unit tests for Omarchy detection, wiring classification, and idempotent envs.conf editing.
- Verified live on an Omarchy session: `--install-omarchy-wrapper`, `--wire-omarchy` (live env confirmed via a Hyprland-spawned probe + persisted; `hyprctl configerrors` clean), `--doctor`, silent first-launch + one-shot guard, and staged `make install`/`uninstall` of the wrapper.

🤖 Generated with [Claude Code](https://claude.com/claude-code)