### PR TITLE
fix: install the manpage to its file path, not the man1 dir

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -51,7 +51,7 @@ install: target/release/tensaku
 	install -Dm644 completions/tensaku.elv $(ELVDIR)/tensaku.elv
 	install -Dm644 completions/tensaku.nu $(NUDIR)/tensaku.nu
 	install -Dm644 completions/tensaku.ts $(FIGDIR)/tensaku.ts
-	install -Dm644 man/tensaku.1 ${PREFIX}/share/man/man1
+	install -Dm644 man/tensaku.1 ${PREFIX}/share/man/man1/tensaku.1
 
 uninstall:
 	rm ${BINDIR}/tensaku


### PR DESCRIPTION
## Problem

`make uninstall` aborts:

```
rm: cannot remove '.../share/man/man1/tensaku.1': Not a directory
make: *** [Makefile:68: uninstall] Error 1
```

The install target writes the manpage to `$(PREFIX)/share/man/man1` **without a filename**, so `install -D` creates a *file* named `man1` rather than `man1/tensaku.1`. `uninstall` then tries to `rm .../man1/tensaku.1` and fails because `man1` is a file, not a directory — aborting the target before it finishes.

## Fix

Install to `$(PREFIX)/share/man/man1/tensaku.1`. The uninstall target's existing `rm .../man1/tensaku.1` then matches. (The AUR PKGBUILDs already install to the correct path; only `make install` was affected.)

## Testing

Staged `PREFIX=$tmp make install && PREFIX=$tmp make uninstall`:
- manpage lands at `share/man/man1/tensaku.1`
- both targets exit 0 (uninstall previously exited non-zero)

🤖 Generated with [Claude Code](https://claude.com/claude-code)