### PR TITLE
feat(packaging): post-install message pointing to --wire-omarchy

### DIFF
--- a/.github/workflows/aur-publish.yml
+++ b/.github/workflows/aur-publish.yml
@@ -82,6 +82,10 @@ jobs:
           # Drop in the variant's PKGBUILD.
           cp "app/packaging/${PKGBUILD_DIR}/PKGBUILD" aur/PKGBUILD
 
+          # Optional pacman install scriptlet (e.g. a post_install message).
+          # Variants/repos without one are unaffected.
+          cp "app/packaging/${PKGBUILD_DIR}/"*.install aur/ 2>/dev/null || true
+
           # Pin the version. source/bin reset pkgrel to 1; git's static
           # pkgver= line is metadata only (pkgver() regenerates it at
           # build time), so it keeps its pkgrel.
@@ -130,5 +134,6 @@ jobs:
           git config user.name  "${APP}-release-bot"
           git config user.email "${APP}-release-bot@users.noreply.github.com"
           git add PKGBUILD .SRCINFO
+          git add ./*.install 2>/dev/null || true
           git diff --cached --quiet || git commit -m "Update to $ver"
           git push --quiet -u origin master

--- a/packaging/aur-bin/PKGBUILD
+++ b/packaging/aur-bin/PKGBUILD
@@ -19,6 +19,7 @@ license=('MPL-2.0')
 depends=('gtk4' 'gtk4-layer-shell' 'libadwaita' 'libepoxy' 'fontconfig')
 provides=("$_pkgname=$pkgver")
 conflicts=("$_pkgname" "$_pkgname-git")
+install=tensaku.install
 source_x86_64=("$_pkgname-v$pkgver-x86_64.tar.gz::https://github.com/jondkinney/$_pkgname/releases/download/v$pkgver/$_pkgname-v$pkgver-x86_64.tar.gz")
 source_aarch64=("$_pkgname-v$pkgver-aarch64.tar.gz::https://github.com/jondkinney/$_pkgname/releases/download/v$pkgver/$_pkgname-v$pkgver-aarch64.tar.gz")
 # Placeholders — CI's updpkgsums overwrites with real per-arch hashes per release.

--- a/packaging/aur-bin/tensaku.install
+++ b/packaging/aur-bin/tensaku.install
@@ -1,0 +1,13 @@
+# Shown by pacman after installing Tensaku.
+
+post_install() {
+  cat <<'MSG'
+
+==> Tensaku is installed.
+==> On Omarchy, make it your screenshot editor (replacing Satty):
+==>     tensaku --wire-omarchy
+==> Your screenshot keys will then open captures in Tensaku.
+==> Status any time:  tensaku --doctor
+
+MSG
+}

--- a/packaging/aur-bin/tensaku.install
+++ b/packaging/aur-bin/tensaku.install
@@ -3,11 +3,23 @@
 post_install() {
   cat <<'MSG'
 
-==> Tensaku is installed.
-==> On Omarchy, make it your screenshot editor (replacing Satty):
-==>     tensaku --wire-omarchy
-==> Your screenshot keys will then open captures in Tensaku.
-==> Status any time:  tensaku --doctor
+
+  ================================================================
+  ================================================================
+
+      >>>  TENSAKU INSTALLED -- ONE MORE STEP TO FINISH  <<<
+
+      Run this command to finalize the Omarchy integration
+      (it makes Tensaku your screenshot editor, replacing Satty):
+
+            tensaku --wire-omarchy
+
+      Your screenshot keys will then open captures in Tensaku.
+      Check status any time:   tensaku --doctor
+
+  ================================================================
+  ================================================================
+
 
 MSG
 }

--- a/packaging/aur-git/PKGBUILD
+++ b/packaging/aur-git/PKGBUILD
@@ -16,6 +16,7 @@ depends=('gtk4' 'gtk4-layer-shell' 'libadwaita' 'libepoxy' 'fontconfig')
 makedepends=('rust' 'git')
 provides=("$_pkgname=$pkgver")
 conflicts=("$_pkgname" "$_pkgname-bin")
+install=tensaku.install
 source=("$_pkgname::git+https://github.com/jondkinney/$_pkgname.git")
 sha256sums=('SKIP')
 

--- a/packaging/aur-git/tensaku.install
+++ b/packaging/aur-git/tensaku.install
@@ -1,0 +1,13 @@
+# Shown by pacman after installing Tensaku.
+
+post_install() {
+  cat <<'MSG'
+
+==> Tensaku is installed.
+==> On Omarchy, make it your screenshot editor (replacing Satty):
+==>     tensaku --wire-omarchy
+==> Your screenshot keys will then open captures in Tensaku.
+==> Status any time:  tensaku --doctor
+
+MSG
+}

--- a/packaging/aur-git/tensaku.install
+++ b/packaging/aur-git/tensaku.install
@@ -3,11 +3,23 @@
 post_install() {
   cat <<'MSG'
 
-==> Tensaku is installed.
-==> On Omarchy, make it your screenshot editor (replacing Satty):
-==>     tensaku --wire-omarchy
-==> Your screenshot keys will then open captures in Tensaku.
-==> Status any time:  tensaku --doctor
+
+  ================================================================
+  ================================================================
+
+      >>>  TENSAKU INSTALLED -- ONE MORE STEP TO FINISH  <<<
+
+      Run this command to finalize the Omarchy integration
+      (it makes Tensaku your screenshot editor, replacing Satty):
+
+            tensaku --wire-omarchy
+
+      Your screenshot keys will then open captures in Tensaku.
+      Check status any time:   tensaku --doctor
+
+  ================================================================
+  ================================================================
+
 
 MSG
 }

--- a/packaging/aur/PKGBUILD
+++ b/packaging/aur/PKGBUILD
@@ -14,6 +14,7 @@ url='https://github.com/jondkinney/tensaku'
 license=('MPL-2.0')
 depends=('gtk4' 'gtk4-layer-shell' 'libadwaita' 'libepoxy' 'fontconfig')
 makedepends=('rust')
+install=tensaku.install
 source=("$pkgname-$pkgver.tar.gz::$url/archive/refs/tags/v$pkgver.tar.gz")
 sha256sums=('52762f03a109afa1749e941d2ce2ba9e1956e4fd1975347c0cd92ddfb6e35968')
 

--- a/packaging/aur/tensaku.install
+++ b/packaging/aur/tensaku.install
@@ -1,0 +1,13 @@
+# Shown by pacman after installing Tensaku.
+
+post_install() {
+  cat <<'MSG'
+
+==> Tensaku is installed.
+==> On Omarchy, make it your screenshot editor (replacing Satty):
+==>     tensaku --wire-omarchy
+==> Your screenshot keys will then open captures in Tensaku.
+==> Status any time:  tensaku --doctor
+
+MSG
+}

--- a/packaging/aur/tensaku.install
+++ b/packaging/aur/tensaku.install
@@ -3,11 +3,23 @@
 post_install() {
   cat <<'MSG'
 
-==> Tensaku is installed.
-==> On Omarchy, make it your screenshot editor (replacing Satty):
-==>     tensaku --wire-omarchy
-==> Your screenshot keys will then open captures in Tensaku.
-==> Status any time:  tensaku --doctor
+
+  ================================================================
+  ================================================================
+
+      >>>  TENSAKU INSTALLED -- ONE MORE STEP TO FINISH  <<<
+
+      Run this command to finalize the Omarchy integration
+      (it makes Tensaku your screenshot editor, replacing Satty):
+
+            tensaku --wire-omarchy
+
+      Your screenshot keys will then open captures in Tensaku.
+      Check status any time:   tensaku --doctor
+
+  ================================================================
+  ================================================================
+
 
 MSG
 }


### PR DESCRIPTION
## What

After a package install, print the one manual step left to make Tensaku Omarchy's screenshot editor:

```
==> Tensaku is installed.
==> On Omarchy, make it your screenshot editor (replacing Satty):
==>     tensaku --wire-omarchy
==> Your screenshot keys will then open captures in Tensaku.
==> Status any time:  tensaku --doctor
```

This reaches the install-and-forget user who never runs `tensaku` in a terminal (everyone else already gets the hint from `--doctor` / `--install-omarchy-wrapper`).

## Changes

- `packaging/{aur,aur-bin,aur-git}/tensaku.install` — pacman `post_install` scriptlet.
- The three PKGBUILDs reference it via `install=tensaku.install`.
- `aur-publish.yml` — generically ship an optional `packaging/<dir>/*.install` to the AUR repo (copy + `git add`). Variants/repos without one are unaffected.

## Shared-workflow note

`aur-publish.yml` is byte-identical across the `hyprcorrect`/`mousehop`/`tensaku`/`vernier` cohort (drift-checked). The change here is **generic** (no repo-specific names), and the identical change is going to the other three repos so the cohort stays in sync. **These four workflow PRs should merge together** or the drift check will go red until they all match.

## Testing

- `bash -n` on each scriptlet: clean.
- `makepkg --printsrcinfo` for all three variants emits `install = tensaku.install`.
- `aur-publish.yml` validated as YAML.

🤖 Generated with [Claude Code](https://claude.com/claude-code)