### PR TITLE
fix(doctor): accurate Omarchy reporting

### DIFF
--- a/src/doctor.rs
+++ b/src/doctor.rs
@@ -57,15 +57,15 @@ pub fn run() -> Result<()> {
         }
     }
 
-    if crate::omarchy_wrapper::is_omarchy() {
-        report_omarchy_wrapper();
-    }
-
     println!();
     if missing == 0 {
-        println!("All good — every tool Tensaku's workflow uses is present.");
+        println!("All good — every external tool Tensaku's workflow uses is present.");
     } else {
         println!("{missing} missing. Tensaku still runs, but the noted features won't work.");
+    }
+
+    if crate::omarchy_wrapper::is_omarchy() {
+        report_omarchy_wrapper();
     }
     Ok(())
 }
@@ -73,40 +73,45 @@ pub fn run() -> Result<()> {
 /// On Omarchy, report whether the screenshot wrapper is installed and
 /// whether `$OMARCHY_SCREENSHOT_EDITOR` is wired to it.
 fn report_omarchy_wrapper() {
-    use crate::omarchy_wrapper::{Wiring, classify_wiring, wrapper_path};
+    use crate::omarchy_wrapper::{Wiring, classify_wiring, installed_wrapper, wrapper_path};
 
     println!();
-    println!("Omarchy detected — screenshot wrapper:");
+    println!("Omarchy detected — screenshot integration:");
 
-    let wrapper = match wrapper_path() {
-        Ok(p) => p,
-        Err(_) => {
-            println!("  [miss]  can't locate ~/.local/bin (is $HOME set?)");
-            return;
+    // A packaged /usr/bin/tensaku-edit counts as installed, not just the
+    // per-user copy; wiring is classified against whichever exists (or the
+    // path we'd install to), so this matches what --wire-omarchy does.
+    let wrapper = installed_wrapper();
+    let mut needs_setup = false;
+
+    match &wrapper {
+        Some(p) => println!("  [ ok ]  wrapper installed: {}", p.display()),
+        None => {
+            println!("  [miss]  wrapper not installed");
+            needs_setup = true;
         }
-    };
-
-    if wrapper.exists() {
-        println!("  [ ok ]  wrapper installed: {}", wrapper.display());
-    } else {
-        println!("  [miss]  wrapper not installed: {}", wrapper.display());
-        println!("          run: tensaku --install-omarchy-wrapper");
     }
 
-    match classify_wiring(std::env::var_os("OMARCHY_SCREENSHOT_EDITOR"), &wrapper) {
-        Wiring::Correct => {
-            println!("  [ ok ]  OMARCHY_SCREENSHOT_EDITOR points at the wrapper");
+    if let Some(target) = wrapper.or_else(|| wrapper_path().ok()) {
+        match classify_wiring(std::env::var_os("OMARCHY_SCREENSHOT_EDITOR"), &target) {
+            Wiring::Correct => {
+                println!("  [ ok ]  OMARCHY_SCREENSHOT_EDITOR points at the wrapper");
+            }
+            Wiring::Elsewhere(other) => {
+                println!(
+                    "  [miss]  OMARCHY_SCREENSHOT_EDITOR points at {}",
+                    other.display()
+                );
+                needs_setup = true;
+            }
+            Wiring::Unset => {
+                println!("  [miss]  OMARCHY_SCREENSHOT_EDITOR is not set");
+                needs_setup = true;
+            }
         }
-        Wiring::Elsewhere(other) => {
-            println!(
-                "  [miss]  OMARCHY_SCREENSHOT_EDITOR points at {}",
-                other.display()
-            );
-            println!("          point it at the wrapper, then run: hyprctl reload");
-        }
-        Wiring::Unset => {
-            println!("  [miss]  OMARCHY_SCREENSHOT_EDITOR is not set");
-            println!("          point it at the wrapper, then run: hyprctl reload");
-        }
+    }
+
+    if needs_setup {
+        println!("          → run: tensaku --wire-omarchy");
     }
 }

--- a/src/omarchy_wrapper.rs
+++ b/src/omarchy_wrapper.rs
@@ -256,6 +256,20 @@ fn find_or_install_wrapper() -> Result<PathBuf> {
     Ok(p)
 }
 
+/// The wrapper that is actually present, if any — a packaged `tensaku-edit`
+/// on `$PATH` (e.g. `/usr/bin`) wins, else the per-user copy if it exists.
+/// Read-only: unlike [`find_or_install_wrapper`] it installs nothing, so
+/// `--doctor` can report the true state without side effects.
+pub(crate) fn installed_wrapper() -> Option<PathBuf> {
+    if let Some(p) = which(WRAPPER_NAME) {
+        return Some(p);
+    }
+    match wrapper_path() {
+        Ok(p) if p.exists() => Some(p),
+        _ => None,
+    }
+}
+
 /// Does a system install already provide the wrapper? A package (AUR /
 /// `make install`) drops `tensaku-edit` into a system bindir on `$PATH`
 /// (e.g. `/usr/bin`); a user-local copy would only shadow it. True when a


### PR DESCRIPTION
## Problem

On a machine where Tensaku is installed but not yet wired, `--doctor` printed a confusing and partly incorrect report:

```
Omarchy detected — screenshot wrapper:
  [miss]  wrapper not installed: /home/.../.local/bin/tensaku-edit
          run: tensaku --install-omarchy-wrapper
  [miss]  OMARCHY_SCREENSHOT_EDITOR points at satty
          point it at the wrapper, then run: hyprctl reload

All good — every tool Tensaku's workflow uses is present.
```

1. **False "wrapper not installed"** — doctor only checked `~/.local/bin/tensaku-edit`, but since v0.26.0 the package ships `/usr/bin/tensaku-edit`. `--wire-omarchy` already recognizes the packaged wrapper; doctor didn't.
2. **"All good" contradicts the misses** — that line is scoped to the external tools (grim/slurp/wl-copy) but was printed *after* the Omarchy `[miss]` lines.
3. **Hints didn't mention `--wire-omarchy`** — the one command that installs the wrapper (if needed) and wires the env in one go.

## Fix

- New read-only `installed_wrapper()` (packaged `tensaku-edit` on `$PATH` wins, else the per-user copy). Doctor reports the true state, classifies wiring against it, and installs nothing.
- Tool summary moved above the Omarchy section.
- Single `→ run: tensaku --wire-omarchy` hint.

## After

```
All good — every external tool Tensaku's workflow uses is present.

Omarchy detected — screenshot integration:
  [ ok ]  wrapper installed: /usr/bin/tensaku-edit
  [miss]  OMARCHY_SCREENSHOT_EDITOR points at satty
          → run: tensaku --wire-omarchy
```

## Testing

- `cargo fmt` / `clippy -D warnings` / `cargo test` (35 pass).
- Verified live: wired machine → all `[ ok ]`; simulated `OMARCHY_SCREENSHOT_EDITOR=satty` → wrapper `[ ok ]` + wiring `[miss]` + single hint, with the tool summary above the section.

🤖 Generated with [Claude Code](https://claude.com/claude-code)