### PR TITLE
fix(doctor): report envs.conf wiring, not just the live env

### DIFF
--- a/src/doctor.rs
+++ b/src/doctor.rs
@@ -73,7 +73,9 @@ pub fn run() -> Result<()> {
 /// On Omarchy, report whether the screenshot wrapper is installed and
 /// whether `$OMARCHY_SCREENSHOT_EDITOR` is wired to it.
 fn report_omarchy_wrapper() {
-    use crate::omarchy_wrapper::{Wiring, classify_wiring, installed_wrapper, wrapper_path};
+    use crate::omarchy_wrapper::{
+        Wiring, classify_wiring, configured_editor, installed_wrapper, wrapper_path,
+    };
 
     println!();
     println!("Omarchy detected — screenshot integration:");
@@ -93,19 +95,40 @@ fn report_omarchy_wrapper() {
     }
 
     if let Some(target) = wrapper.or_else(|| wrapper_path().ok()) {
-        match classify_wiring(std::env::var_os("OMARCHY_SCREENSHOT_EDITOR"), &target) {
+        // envs.conf is the persistent wiring — what screenshots will use
+        // going forward, so it (not the live env) drives the verdict. The
+        // live $OMARCHY_SCREENSHOT_EDITOR only reflects the running session
+        // and goes stale after --wire-omarchy until the next login; we read
+        // it only to flag a wiring that isn't active in this session yet, or
+        // a session-only value that won't survive a relogin.
+        let active_correct = matches!(
+            classify_wiring(std::env::var_os("OMARCHY_SCREENSHOT_EDITOR"), &target),
+            Wiring::Correct
+        );
+
+        match classify_wiring(configured_editor(), &target) {
             Wiring::Correct => {
-                println!("  [ ok ]  OMARCHY_SCREENSHOT_EDITOR points at the wrapper");
+                println!("  [ ok ]  OMARCHY_SCREENSHOT_EDITOR wired in envs.conf");
+                if !active_correct {
+                    println!("          (active after next login)");
+                }
             }
             Wiring::Elsewhere(other) => {
                 println!(
-                    "  [miss]  OMARCHY_SCREENSHOT_EDITOR points at {}",
+                    "  [miss]  envs.conf wires OMARCHY_SCREENSHOT_EDITOR at {}",
                     other.display()
                 );
                 needs_setup = true;
             }
             Wiring::Unset => {
-                println!("  [miss]  OMARCHY_SCREENSHOT_EDITOR is not set");
+                if active_correct {
+                    println!(
+                        "  [miss]  OMARCHY_SCREENSHOT_EDITOR is set this session but \
+                         not in envs.conf — it won't persist"
+                    );
+                } else {
+                    println!("  [miss]  OMARCHY_SCREENSHOT_EDITOR is not wired in envs.conf");
+                }
                 needs_setup = true;
             }
         }

--- a/src/omarchy_wrapper.rs
+++ b/src/omarchy_wrapper.rs
@@ -315,6 +315,23 @@ fn env_line_value(line: &str) -> Option<String> {
     Some(value.to_string())
 }
 
+/// The `OMARCHY_SCREENSHOT_EDITOR` value configured in `envs.conf`, if any.
+///
+/// Unlike the live `$OMARCHY_SCREENSHOT_EDITOR` (which reflects the running
+/// session and goes stale after `--wire-omarchy` until the next login), this
+/// is the *persistent* wiring — what screenshots will use going forward, and
+/// what `--doctor` should report. First matching directive wins, mirroring
+/// [`apply_env_line`]. Read-only and best-effort: a missing or unreadable
+/// file reads as "not configured".
+pub(crate) fn configured_editor() -> Option<OsString> {
+    let path = hypr_envs_conf().ok()?;
+    let contents = std::fs::read_to_string(path).ok()?;
+    contents
+        .lines()
+        .find_map(env_line_value)
+        .map(OsString::from)
+}
+
 /// An inline `env OMARCHY_SCREENSHOT_EDITOR=<value>` prefix on an `exec`
 /// bind, returned as `<value>`. This is the per-command form (NAME=value),
 /// distinct from the envs.conf directive form (NAME,value).


### PR DESCRIPTION
## Problem

`tensaku --doctor` classified `OMARCHY_SCREENSHOT_EDITOR` from the running process environment (`std::env::var_os`). That value reflects the **live Hyprland session**, which only picks up `env =` directives from `~/.config/hypr/envs.conf` at login. So immediately after `tensaku --wire-omarchy`, a correctly-wired setup still reported `[miss]` until the user relogged.

A subshell can't fix this — `envs.conf` is a Hyprland config, not a shell rc, so a child shell would inherit the exact same stale session env.

## Fix

Read the **persistent** wiring straight from `envs.conf` and let that drive the verdict:

- New read-only `configured_editor()` in `omarchy_wrapper.rs`, reusing the existing `env_line_value` parser (first matching directive wins, mirroring `apply_env_line`).
- The live env is now consulted only for context:
  - wired in `envs.conf` but not active this session → `(active after next login)`
  - correct this session but absent from `envs.conf` → flagged as won't-persist

## Test plan

- `cargo build` clean
- `cargo test omarchy` — 16 passed
- Existing `env_line_value` tests cover the parser the new function reuses

🤖 Generated with [Claude Code](https://claude.com/claude-code)