### PR TITLE
ci(release-plz): gate release-pr on the publish job to stop phantom releases

### DIFF
--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -45,6 +45,10 @@ jobs:
   # every push to main.
   release-pr:
     name: release-plz PR
+    # Gate on the publish job: a release-pr that runs while a publish is
+    # still in flight reads a pre-publish registry and opens phantom
+    # patch releases (seen after rapid back-to-back release merges).
+    needs: release
     runs-on: ubuntu-latest
     container:
       image: ghcr.io/gtk-rs/gtk4-rs/gtk4:latest


### PR DESCRIPTION
## Problem

`release-plz.yml` runs two jobs in parallel with no ordering between them:

- **`release`** — publishes crates + cuts the tag/GitHub Release (~3–4 min)
- **`release-pr`** — computes the next release PR by diffing local source against the **registry**

When two release PRs are merged in quick succession — before the first merge's publish finishes — the second run's `release-pr` queries the registry while it still shows the *previous* version, "rediscovers" the already-merged changes, and opens a phantom patch-release PR with no real content. Merging a phantom spawns the next one, so they chain.

This produced an empty `vX → vX+1 → vX+2` patch-release chain in a sibling repo (vernier) after two release PRs were merged ~2 minutes apart, and a concurrent AUR `git push` race on the same release.

## Fix

Add `needs: release` to the `release-pr` job so it runs only after the publish completes and the registry/tags are settled.

- No behavior change on normal pushes: the `release` job is a fast no-op when nothing is pending, then `release-pr` runs as before.
- If a publish fails, `release-pr` is skipped until it's fixed — desirable (don't compute the next PR off a half-published state).

Coordinated identical change across hyprcorrect / mousehop / tensaku / vernier.
