### PR TITLE
fix(welcome): force SpinButton repaint so detected scale pre-fills

### DIFF
--- a/src/ui/welcome.rs
+++ b/src/ui/welcome.rs
@@ -226,6 +226,23 @@ impl Component for WelcomeDialog {
         };
         let widgets = view_output!();
 
+        // The SpinButton's value is set during widget construction (via
+        // the `#[watch] set_value` binding), which runs before the
+        // window is mapped. GTK updates the underlying value/text buffer
+        // correctly, but the pre-map paint leaves the *rendered* glyphs
+        // showing the adjustment's default (1.0) — so the field looks
+        // un-prefilled even though its value is right. Re-assert the
+        // value on an idle tick after `present()`, toggling through a
+        // different value first so GTK registers a real `value-changed`
+        // (set_value to the current value is a no-op and won't repaint).
+        let spin = widgets.spin.clone();
+        let target: f64 = model.value.into();
+        relm4::gtk::glib::idle_add_local_once(move || {
+            let bump = if target == 1.0 { 1.1 } else { 1.0 };
+            spin.set_value(bump);
+            spin.set_value(target);
+        });
+
         // Enter saves so the user can confirm with the keyboard. The
         // controller runs in Capture phase so it fires before the
         // SpinButton's own activation behavior.


### PR DESCRIPTION
## Problem

On the first-run welcome dialog, the **Factor** SpinButton was not visually pre-filling with the detected display scale (e.g. `2.0` on a scale-2 Hyprland monitor) — it rendered `1.0` instead.

The value was actually being set correctly during widget construction via the `#[watch] set_value: model.value.into()` binding — GTK's internal value and text buffer both read `2.0`. But that assignment runs **before the window is mapped/presented**, and the pre-map paint left the *rendered glyphs* showing the adjustment's default of `1.0`. So the field's value was right but it looked un-prefilled. A plain `set_value` afterward doesn't help, because setting a SpinButton to the value it already holds is a no-op and triggers no repaint.

## Fix

In `WelcomeDialog::init()`, after `view_output!()`, re-assert the value on an idle tick (so it runs after `present()` maps the window), toggling through a different value first so GTK registers a real `value-changed` and repaints.

## Verification

Forced the first-run dialog (temporarily cleared the persisted `annotation-size-factor`) and launched with a test image on a scale-2.0 Hyprland monitor. The dialog now shows "Detected display scale: **2.00× (Hyprland)**" with the Factor field rendering **2.0** — confirmed by screenshot. Restored the original state afterward.

🤖 Generated with [Claude Code](https://claude.com/claude-code)