### PR TITLE
chore: release v0.26.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.26.4](https://github.com/jondkinney/tensaku/compare/v0.26.3...v0.26.4) - 2026-06-12
+
+### Fixed
+
+- *(welcome)* force SpinButton repaint so detected scale pre-fills
+
 ## [0.26.3](https://github.com/jondkinney/tensaku/compare/v0.26.2...v0.26.3) - 2026-05-30
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1701,7 +1701,7 @@ checksum = "df7f62577c25e07834649fc3b39fafdc597c0a3527dc1c60129201ccfcbaa50c"
 
 [[package]]
 name = "tensaku"
-version = "0.26.3"
+version = "0.26.4"
 dependencies = [
  "anyhow",
  "chrono",
@@ -1738,7 +1738,7 @@ dependencies = [
 
 [[package]]
 name = "tensaku_cli"
-version = "0.26.3"
+version = "0.26.4"
 dependencies = [
  "clap",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -78,7 +78,7 @@ clap_mangen = "0.3.0"
 members = [ "cli" ]
 
 [workspace.package]
-version = "0.26.3"
+version = "0.26.4"
 edition = "2024"
 # Tensaku is a fork of Satty; Matthias Gabriel is retained as the
 # original author per the MPL-2.0 (see NOTICE).
@@ -90,5 +90,5 @@ license = "MPL-2.0"
 
 [workspace.dependencies]
 clap = { version = "4.6.1", features = ["derive"] }
-tensaku_cli = { path = "cli", version = "0.26.3" }
+tensaku_cli = { path = "cli", version = "0.26.4" }
 serde = { version = "1.0", features = ["derive"] }


### PR DESCRIPTION



## 🤖 New release

* `tensaku_cli`: 0.26.3 -> 0.26.4
* `tensaku`: 0.26.3 -> 0.26.4

<details><summary><i><b>Changelog</b></i></summary><p>


## `tensaku`

<blockquote>

## [0.26.4](https://github.com/jondkinney/tensaku/compare/v0.26.3...v0.26.4) - 2026-06-12

### Fixed

- *(welcome)* force SpinButton repaint so detected scale pre-fills
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).