### PR TITLE
fix(toolbars): dismiss swatch tooltips when the color picker closes

### DIFF
--- a/src/ui/toolbars.rs
+++ b/src/ui/toolbars.rs
@@ -1107,6 +1107,20 @@ fn ensure_floating_swatch_tip(near: &gtk::Widget) -> (gtk::Popover, gtk::Label) 
     })
 }
 
+/// Force the shared floating swatch tooltip down, if one is showing.
+///
+/// Needed because the tooltip popover is `autohide(false)` and is only
+/// dismissed by the swatch's motion `leave`. When the picker popover
+/// closes (swatch click, Escape, click-away), the swatch the pointer
+/// was over vanishes with the popover surface, so `leave` never fires
+/// — the tooltip would otherwise stay frozen over the toolbar. Call
+/// this from the picker's `closed` handler to clear it.
+fn dismiss_floating_swatch_tip() {
+    if let Some(pair) = FLOATING_SWATCH_TIP.with(|c| c.borrow().clone()) {
+        pair.0.popdown();
+    }
+}
+
 /// Attach a custom floating tooltip to a swatch inside the picker
 /// Attach a secondary-button GestureClick to `target` that pops up a
 /// small "Save as default" popover at the click point. The popover is
@@ -1190,6 +1204,15 @@ fn attach_floating_swatch_tooltip(target: &impl IsA<gtk::Widget>, text: &str) {
                 let Some(window) = target.root() else {
                     return;
                 };
+                // The picker can close during the delay (the swatch is
+                // clicked before the tooltip ever shows). The swatch
+                // widget survives — the grid is only rebuilt on the next
+                // open, so `root()` still resolves — but a closed popover
+                // unmaps its children. Bail when unmapped, or the tooltip
+                // pops up over the toolbar after the picker is gone.
+                if !target.is_mapped() {
+                    return;
+                }
                 let (popover, label) = ensure_floating_swatch_tip(&target);
                 label.set_label(&text);
                 if let Some(bounds) = target.compute_bounds(&window) {
@@ -4544,6 +4567,10 @@ impl Component for ToolsToolbar {
         {
             let sender = sender.clone();
             popover.connect_closed(move |_| {
+                // The picker surface is gone, so any swatch tooltip that
+                // was up will never get its motion `leave` — dismiss it
+                // explicitly or it freezes over the toolbar.
+                dismiss_floating_swatch_tip();
                 sender.input(ToolsToolbarInput::ClearEmptySlotSelection);
                 sender.output_sender().emit(ToolbarEvent::FocusCanvas);
             });


### PR DESCRIPTION
## Problem

A color-picker swatch tooltip (e.g. "Saved color 1") stays frozen over the toolbar after the color palette closes.

The swatch tooltips use a shared `gtk::Popover` built with `autohide(false)`, parented to the top-level window and only dismissed by the swatch's motion `leave` event. When the picker popover closes (swatch click, Escape, click-away), the hovered swatch vanishes *with the picker surface*, so GTK never delivers `leave` — and the `autohide(false)` tooltip lingers.

## Fix

Two paths needed covering:

1. **Already-shown tooltip** — dismiss it explicitly from the picker's `connect_closed` handler (`dismiss_floating_swatch_tip()`).
2. **Pending show-timer** — the swatch widget survives a close (the grid is only rebuilt on the *next* open, so `root()` still resolves), so a timer armed before the click would fire ~750ms later and pop the tooltip over the bare toolbar. Guard the delayed show on `is_mapped()` — a closed popover unmaps its children — so it bails instead.

`connect_closed` is the single chokepoint that fires regardless of how the picker closes, so all dismissal routes are covered.

## Verification

Built and launched. Verified both the slow-hover-then-close case and the fast-click-before-tooltip case no longer leave a tooltip stranded on the toolbar.

🤖 Generated with [Claude Code](https://claude.com/claude-code)