### PR TITLE
chore: release v0.26.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,33 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.26.6](https://github.com/jondkinney/tensaku/compare/v0.26.5...v0.26.6) - 2026-06-17
+
+### Added
+
+- *(window)* also try the legacy Hyprland dispatcher for older versions
+- *(window)* floor crop-resize width to keep the top bar one row
+- *(window)* hold crop/grow window size across moves on Hyprland
+- *(a11y)* arrow-key toolbar nav + Esc cancels crop from any control
+- *(crop+ux)* aspect-locked arrow resize, sticky control focus, smarter top-bar wrap
+- *(crop+ux)* view-window crop model, non-destructive transforms, full keyboard nav
+- *(ux)* session batch — glyph tooltips, Pen/Counter, slider+cursor fixes, group move
+
+### Fixed
+
+- *(crop)* match the resize popover's units dropdown padding to the toolbar
+- *(window)* drop the single-row floor's +8px buffer to close the tool gap
+- *(crop)* scrollbars track the crop region, not the full image
+- *(crop)* plain wheel adjusts the crop; mouse only touches crop handles
+- *(window)* tighten the single-row floor to the packed toolbar width
+- *(selection)* don't show handles for a hidden layer
+- *(arrow)* curve to the top by default
+- *(crop)* un-invert Shift+arrow resize under a locked aspect ratio
+
+### Other
+
+- *(crop)* renderer core for materialized-crop model (not yet wired)
+
 ## [0.26.5](https://github.com/jondkinney/tensaku/compare/v0.26.4...v0.26.5) - 2026-06-12
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1701,7 +1701,7 @@ checksum = "df7f62577c25e07834649fc3b39fafdc597c0a3527dc1c60129201ccfcbaa50c"
 
 [[package]]
 name = "tensaku"
-version = "0.26.5"
+version = "0.26.6"
 dependencies = [
  "anyhow",
  "chrono",
@@ -1738,7 +1738,7 @@ dependencies = [
 
 [[package]]
 name = "tensaku_cli"
-version = "0.26.5"
+version = "0.26.6"
 dependencies = [
  "clap",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -78,7 +78,7 @@ clap_mangen = "0.3.0"
 members = [ "cli" ]
 
 [workspace.package]
-version = "0.26.5"
+version = "0.26.6"
 edition = "2024"
 # Tensaku is a fork of Satty; Matthias Gabriel is retained as the
 # original author per the MPL-2.0 (see NOTICE).
@@ -90,5 +90,5 @@ license = "MPL-2.0"
 
 [workspace.dependencies]
 clap = { version = "4.6.1", features = ["derive"] }
-tensaku_cli = { path = "cli", version = "0.26.5" }
+tensaku_cli = { path = "cli", version = "0.26.6" }
 serde = { version = "1.0", features = ["derive"] }


### PR DESCRIPTION



## 🤖 New release

* `tensaku_cli`: 0.26.5 -> 0.26.6
* `tensaku`: 0.26.5 -> 0.26.6

<details><summary><i><b>Changelog</b></i></summary><p>


## `tensaku`

<blockquote>

## [0.26.6](https://github.com/jondkinney/tensaku/compare/v0.26.5...v0.26.6) - 2026-06-17

### Added

- *(window)* also try the legacy Hyprland dispatcher for older versions
- *(window)* floor crop-resize width to keep the top bar one row
- *(window)* hold crop/grow window size across moves on Hyprland
- *(a11y)* arrow-key toolbar nav + Esc cancels crop from any control
- *(crop+ux)* aspect-locked arrow resize, sticky control focus, smarter top-bar wrap
- *(crop+ux)* view-window crop model, non-destructive transforms, full keyboard nav
- *(ux)* session batch — glyph tooltips, Pen/Counter, slider+cursor fixes, group move

### Fixed

- *(crop)* match the resize popover's units dropdown padding to the toolbar
- *(window)* drop the single-row floor's +8px buffer to close the tool gap
- *(crop)* scrollbars track the crop region, not the full image
- *(crop)* plain wheel adjusts the crop; mouse only touches crop handles
- *(window)* tighten the single-row floor to the packed toolbar width
- *(selection)* don't show handles for a hidden layer
- *(arrow)* curve to the top by default
- *(crop)* un-invert Shift+arrow resize under a locked aspect ratio

### Other

- *(crop)* renderer core for materialized-crop model (not yet wired)
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).