### PR TITLE
Fix/clipboard fallback

### DIFF
--- a/src/sketch_board.rs
+++ b/src/sketch_board.rs
@@ -1399,7 +1399,6 @@ impl SketchBoard {
         Ok(())
     }
 
-
     fn handle_copy_filepath(&self) {
         let filepath = match self.last_saved_filepath.borrow().clone() {
             Some(path) => path,

--- a/src/sketch_board.rs
+++ b/src/sketch_board.rs
@@ -1358,7 +1358,20 @@ impl SketchBoard {
         let texture = Texture::for_pixbuf(image);
 
         let result = if let Some(command) = APP_CONFIG.read().copy_command() {
-            self.save_texture_to_external_process(&texture, command)
+            match self.save_texture_to_external_process(&texture, command) {
+                Ok(()) => Ok(()),
+                Err(external_error) => {
+                    // A configured helper (most commonly wl-copy) may not be
+                    // present in a sandbox even though the compositor's native
+                    // clipboard is available. Keep the copy action useful in
+                    // that case, while retaining the helper's persistence
+                    // benefits whenever it is installed.
+                    eprintln!(
+                        "Clipboard command '{command}' failed: {external_error}; falling back to GTK clipboard."
+                    );
+                    self.save_texture_to_clipboard(&texture)
+                }
+            }
         } else {
             self.save_texture_to_clipboard(&texture)
         };
@@ -1399,7 +1412,15 @@ impl SketchBoard {
 
         // Copy the filepath to clipboard
         let result = if let Some(command) = APP_CONFIG.read().copy_command() {
-            self.copy_text_to_external_process(&filepath, command)
+            match self.copy_text_to_external_process(&filepath, command) {
+                Ok(()) => Ok(()),
+                Err(external_error) => {
+                    eprintln!(
+                        "Clipboard command '{command}' failed: {external_error}; falling back to GTK clipboard."
+                    );
+                    self.copy_text_to_clipboard(&filepath)
+                }
+            }
         } else {
             self.copy_text_to_clipboard(&filepath)
         };

--- a/src/sketch_board.rs
+++ b/src/sketch_board.rs
@@ -1358,7 +1358,19 @@ impl SketchBoard {
         let texture = Texture::for_pixbuf(image);
 
         let result = if let Some(command) = APP_CONFIG.read().copy_command() {
-            self.save_texture_to_external_process(&texture, command)
+            match self.save_texture_to_external_process(&texture, command) {
+                Ok(()) => Ok(()),
+                Err(external_error) => {
+                    // A configured helper (most commonly wl-copy) may not be present
+                    // in the flatpak sandbox even though the compositor's native
+                    // clipboard is available. This keeps the copy action useful
+                    // while retaining the helper's persistence.
+                    eprintln!(
+                        "Clipboard command '{command}' failed: {external_error}; falling back to GTK clipboard."
+                    );
+                    self.save_texture_to_clipboard(&texture)
+                }
+            }
         } else {
             self.save_texture_to_clipboard(&texture)
         };
@@ -1399,7 +1411,15 @@ impl SketchBoard {
 
         // Copy the filepath to clipboard
         let result = if let Some(command) = APP_CONFIG.read().copy_command() {
-            self.copy_text_to_external_process(&filepath, command)
+            match self.copy_text_to_external_process(&filepath, command) {
+                Ok(()) => Ok(()),
+                Err(external_error) => {
+                    eprintln!(
+                        "Clipboard command '{command}' failed: {external_error}; falling back to GTK clipboard."
+                    );
+                    self.copy_text_to_clipboard(&filepath)
+                }
+            }
         } else {
             self.copy_text_to_clipboard(&filepath)
         };

--- a/src/sketch_board.rs
+++ b/src/sketch_board.rs
@@ -1399,9 +1399,6 @@ impl SketchBoard {
         Ok(())
     }
 
-    fn copy_text_to_external_process(&self, text: &str, command: &str) -> anyhow::Result<()> {
-        self.save_bytes_to_external_process(text.as_bytes(), command)
-    }
 
     fn handle_copy_filepath(&self) {
         let filepath = match self.last_saved_filepath.borrow().clone() {
@@ -1409,29 +1406,9 @@ impl SketchBoard {
             None => return,
         };
 
-        // Copy the filepath to clipboard
-        let result = if let Some(command) = APP_CONFIG.read().copy_command() {
-            match self.copy_text_to_external_process(&filepath, command) {
-                Ok(()) => Ok(()),
-                Err(external_error) => {
-                    eprintln!(
-                        "Clipboard command '{command}' failed: {external_error}; falling back to GTK clipboard."
-                    );
-                    self.copy_text_to_clipboard(&filepath)
-                }
-            }
-            match self.copy_text_to_external_process(&filepath, command) {
-                Ok(()) => Ok(()),
-                Err(external_error) => {
-                    eprintln!(
-                        "Clipboard command '{command}' failed: {external_error}; falling back to GTK clipboard."
-                    );
-                    self.copy_text_to_clipboard(&filepath)
-                }
-            }
-        } else {
-            self.copy_text_to_clipboard(&filepath)
-        };
+        // Filepaths are always copied through GTK. The configured copy command
+        // is intended for image data (for example, `wl-copy --type image/png`).
+        let result = self.copy_text_to_clipboard(&filepath);
 
         match result {
             Err(e) => log_result(


### PR DESCRIPTION
Basically when Wayland is not available, the copy button in the menu doesn't work nor does the CTRL+C keyboard shortcut because wl-copy is not present. this fix falls back to x11 GTK clipboard function. 
There are a couple more similar issues that will be fixed separately, but this one bothers me today.
The AI helped me with this one and you'll need to test against Wayland but it looks good to me and solved my problem with flatpak install and x11.

Jon, if you want issues submitted to track fixes like these, just let me know.