### PR TITLE
chore: release v0.26.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,28 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.26.7](https://github.com/jondkinney/tensaku/compare/v0.26.6...v0.26.7) - 2026-08-15
+
+### Added
+
+- *(scroll-capture)* persist the restorable region on every shape commit
+- *(config)* config.toml as the canonical store for GUI preferences
+- *(scroll-capture)* manual scrolling, faster auto capture, robust stitching
+- *(capture)* force opaque screencopy output with format regression tests
+- add version label to preferences dialog
+
+### Fixed
+
+- *(scroll-capture)* hold an exclusive keyboard grab in every interactive state
+- *(scroll-capture)* deliver Esc and the restore key before a region is dragged
+- *(render)* tile textures past GL limits; cancel spring-back timer on unrealize
+
+### Other
+
+- *(readme)* document scroll capture, unified preferences, and new config keys
+- update star history chart
+- self-host star history chart
+
 ## [0.26.6](https://github.com/jondkinney/tensaku/compare/v0.26.5...v0.26.6) - 2026-06-17
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1761,7 +1761,7 @@ checksum = "df7f62577c25e07834649fc3b39fafdc597c0a3527dc1c60129201ccfcbaa50c"
 
 [[package]]
 name = "tensaku"
-version = "0.26.6"
+version = "0.26.7"
 dependencies = [
  "anyhow",
  "chrono",
@@ -1801,7 +1801,7 @@ dependencies = [
 
 [[package]]
 name = "tensaku_cli"
-version = "0.26.6"
+version = "0.26.7"
 dependencies = [
  "clap",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -87,7 +87,7 @@ clap_mangen = "0.3.0"
 members = [ "cli" ]
 
 [workspace.package]
-version = "0.26.6"
+version = "0.26.7"
 edition = "2024"
 # Tensaku is a fork of Satty; Matthias Gabriel is retained as the
 # original author per the MPL-2.0 (see NOTICE).
@@ -99,5 +99,5 @@ license = "MPL-2.0"
 
 [workspace.dependencies]
 clap = { version = "4.6.1", features = ["derive"] }
-tensaku_cli = { path = "cli", version = "0.26.6" }
+tensaku_cli = { path = "cli", version = "0.26.7" }
 serde = { version = "1.0", features = ["derive"] }


### PR DESCRIPTION



## 🤖 New release

* `tensaku_cli`: 0.26.6 -> 0.26.7 (✓ API compatible changes)
* `tensaku`: 0.26.6 -> 0.26.7

<details><summary><i><b>Changelog</b></i></summary><p>


## `tensaku`

<blockquote>

## [0.26.7](https://github.com/jondkinney/tensaku/compare/v0.26.6...v0.26.7) - 2026-08-15

### Added

- *(scroll-capture)* persist the restorable region on every shape commit
- *(config)* config.toml as the canonical store for GUI preferences
- *(scroll-capture)* manual scrolling, faster auto capture, robust stitching
- *(capture)* force opaque screencopy output with format regression tests
- add version label to preferences dialog

### Fixed

- *(scroll-capture)* hold an exclusive keyboard grab in every interactive state
- *(scroll-capture)* deliver Esc and the restore key before a region is dragged
- *(render)* tile textures past GL limits; cancel spring-back timer on unrealize

### Other

- *(readme)* document scroll capture, unified preferences, and new config keys
- update star history chart
- self-host star history chart
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).