### PR TITLE
chore: release v0.27.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,131 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.27.0](https://github.com/jondkinney/tensaku/compare/v0.26.7...v0.27.0) - 2026-08-21
+
+### Added
+
+- *(pin)* place and stack pins on sway too
+- *(pin)* degrade gracefully off Hyprland
+- *(pin)* shape the pin like the display
+- *(pin,capture)* square stacked pins, click-to-edit, untitled names
+- *(capture)* the size pill takes the shot, and the puck matches
+- *(capture)* a shutter button beside the restored region's puck
+- *(capture)* the cursor says what a restored region will do
+- *(capture)* grips and a move puck on a restored region
+- *(capture)* adjust a restored region, and hide its measurement
+- *(capture)* R restores the last region
+- *(capture)* show the selection's pixel size while dragging
+- *(scroll-capture)* the same pointer guides as the area capture
+- *(capture)* A switches scrolling capture back to a normal one
+- *(capture)* crosshair guides before the drag starts
+- *(capture)* own the region selection, with window and mode switching
+- *(pin)* tooltips, copy confirmations, and drag-out
+- *(pin)* copy path saves the shot when it has none
+- *(canvas)* the plain wheel walks whichever axis overflows
+- *(pin)* pin the finished shot to the desktop
+- *(spotlight)* Alt+wheel adjusts the loupe
+- *(spotlight)* a magnification slider turns a spotlight into a loupe
+- *(text)* an outlined style that reads over anything
+- *(blur)* a Secure checkbox states what each mode can undo
+- *(shapes)* f toggles fill on any fillable selection
+- *(shapes)* a single r / e toggles a selected shape's fill
+- *(canvas)* right-click an annotation to restack it
+- *(stacking)* text lands above artwork, counters above text
+- *(pointer)* plain wheel zooms when the Pointer is armed
+- *(prefs)* remove the invert-scrolling preference
+- *(canvas)* plain wheel sizes the next annotation
+- *(counter)* preview the badge on the canvas, not in the cursor
+- *(counter)* the cursor previews the badge it will stamp
+- *(counter)* stamp the counter over text instead of grabbing it
+- *(shapes)* shape tool buttons show their own fill, and widen the double-tap
+- *(shapes)* double-tap a shape's key to toggle its fill, replacing F
+- *(selection)* grab large annotations by their border, draw in their interior
+
+### Fixed
+
+- *(pin)* crop the preview to the capture's top, not its middle
+- *(pin)* drop the mat and the rounded corner
+- *(pin)* float, pin and place through the Lua dispatch API
+- *(pin)* tooltips use the app's own, and the drag polls twice a frame
+- *(pin)* the drag follows the pointer itself
+- *(pin)* drag follows the pointer, and tooltips get out of the way
+- *(pin)* slots follow where pins are, and moving one keeps up
+- *(capture)* the shutter pill and puck carry their own cursors
+- *(pin)* copy works, preview shows the shot, pins stack
+- *(capture)* puck back to centre, size and shutter parked beneath it
+- *(capture)* size readouts agree with the editor
+- *(scroll-capture)* stop spawning hyprctl on every drag event
+- *(capture)* hints along the bottom, not across the middle
+- *(capture)* don't capture the overlay you just switched away from
+- *(scroll-capture)* dim to the same weight as the area capture
+- *(capture)* the area overlay wears the scroll capture's pill
+- *(capture)* centre the area overlay's hint like the scroll one
+- *(text)* the outline is white, like CleanShot X
+- *(capture)* crosshair pointer while aiming a region
+- *(capture)* cache the backdrop; stop toasting the saved text style
+- *(capture)* take the picture before the overlay exists
+- *(capture)* let the overlay leave the screen before capturing it
+- *(capture)* merge the --capture flag into the configuration
+- *(pin)* back every pin with a file so the drag carries a path
+- *(pin)* drag a thumbnail, not the whole capture
+- *(pin)* ask where to save when nothing is configured
+- *(pin)* render the pixels the pin needs
+- *(text)* Ctrl+Shift+wheel reaches the outlined style
+- *(spotlight)* make magnification global, like darkness
+- *(spotlight)* render the loupe in the pass that renders spotlights
+- *(blur)* stop the secure blur seeding itself from its own glow
+- *(blur)* put Secure beside the picker, not inside it
+- *(ellipse)* grab the curve, not the box around it
+- *(picking)* size the border-grab band in screen pixels
+- *(shapes)* apply the r / e fill toggle instead of dropping it
+- *(canvas)* stop inverting the compositor's scroll delta
+- *(counter)* tighten the badge's lead on the pointer
+- *(counter)* system cursor, offset badge
+- *(counter)* move the pointer off the number it previews
+- *(counter)* the cursor over text matches what the click does
+- *(shapes)* keep each shape's fill toggle to that shape
+- *(toolbar)* bundle the shape buttons' filled glyphs
+- *(selection)* dismiss a selection before drawing inside a large annotation
+- *(text)* clicking away from an in-progress text only ends it
+- *(text)* grab an existing text box rather than stacking a new one on it
+- *(input)* ignore modifiers left over from the launch chord
+- *(arrow)* thicken only the tail when zoomed out
+- *(canvas)* stop the expanded background showing a line per expansion
+- *(omarchy)* opt out of default window opacity, wiring through Lua
+- *(selection)* shrink the selection halo with the artwork when zoomed out
+- *(canvas)* settle the edge extension away from the boundary
+- *(canvas)* extend the image edge per line instead of one flat colour
+- *(text)* wrap auto-fit text at the image edge while typing
+- *(stitch)* keep a fixed edge's drop shadow out of every seam
+- *(stitch)* crop viewport-fixed bands out of the motion search
+- *(scroll-capture)* let the page inside a selected region take wheel and keys
+- *(scroll-capture)* target the overlay's monitor for capture and pointer warps
+- *(render)* tile the spotlight overlay past GL texture limits
+
+### Other
+
+- *(pin)* let the compositor move the pin
+- *(pin)* lead the pointer by the latency instead of chasing it
+- *(pin)* read the pointer off-thread, move on the frame clock
+- *(capture)* composite the selection instead of painting it
+- Revert "feat(pointer): plain wheel zooms when the Pointer is armed"
+- drop the two removed preferences from the README
+- *(canvas)* add probes for tile seams and flat-render uniformity
+- *(canvas)* grow the raster by re-viewing it, not by copying it
+- *(canvas)* add a grow-raster digest harness
+- *(canvas)* reuse background textures across an auto-grow
+- *(blur)* read back only the blurred region, and stop leaking textures
+- *(canvas)* stop copying the raster twice on every re-upload
+- *(canvas)* add an env-gated frame profiler
+- update star history chart
+- update star history chart
+- update star history chart
+- update star history chart
+- *(stitch)* use is_multiple_of in the sparse-doc fixture
+- *(stitch)* replay harness takes TENSAKU_STITCH_REPLAY_AXIS
+- update star history chart
+
 ## [0.26.7](https://github.com/jondkinney/tensaku/compare/v0.26.6...v0.26.7) - 2026-08-15
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1761,7 +1761,7 @@ checksum = "df7f62577c25e07834649fc3b39fafdc597c0a3527dc1c60129201ccfcbaa50c"
 
 [[package]]
 name = "tensaku"
-version = "0.26.7"
+version = "0.27.0"
 dependencies = [
  "anyhow",
  "chrono",
@@ -1802,7 +1802,7 @@ dependencies = [
 
 [[package]]
 name = "tensaku_cli"
-version = "0.26.7"
+version = "0.27.0"
 dependencies = [
  "clap",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -88,7 +88,7 @@ clap_mangen = "0.3.0"
 members = [ "cli" ]
 
 [workspace.package]
-version = "0.26.7"
+version = "0.27.0"
 edition = "2024"
 # Tensaku is a fork of Satty; Matthias Gabriel is retained as the
 # original author per the MPL-2.0 (see NOTICE).
@@ -100,5 +100,5 @@ license = "MPL-2.0"
 
 [workspace.dependencies]
 clap = { version = "4.6.1", features = ["derive"] }
-tensaku_cli = { path = "cli", version = "0.26.7" }
+tensaku_cli = { path = "cli", version = "0.27.0" }
 serde = { version = "1.0", features = ["derive"] }

--- a/src/pin.rs
+++ b/src/pin.rs
@@ -143,31 +143,27 @@ pub fn open(image: &Pixbuf, actions: PinActions) -> Pin {
 
     // Float it, show it on every workspace, and put it in its slot —
     // once it has a surface for the compositor to match on.
-    if on_hyprland() {
-        let slot = next_slot();
+    let desktop = Desktop::detect();
+    if desktop.places_windows() {
+        let slot = next_slot(desktop);
         window.connect_map(move |_| {
             // Not immediately: `map` is this side's word for "shown",
             // and the compositor has not necessarily registered the
-            // window under its title yet — dispatches sent then report
-            // success and do nothing, which is how a pin ended up
-            // centred and unpinned. Retry until it is there.
+            // window under its title yet — a request naming a window
+            // that isn't there reports success and does nothing, which
+            // is how a pin ended up centred and unpinned. Retry until
+            // it is there.
             let attempts = Cell::new(0);
             gtk::glib::timeout_add_local(SETTLE_INTERVAL, move || {
                 attempts.set(attempts.get() + 1);
-                if !pin_window_exists() {
+                if !desktop.sees_pin() {
                     return if attempts.get() < SETTLE_ATTEMPTS {
                         gtk::glib::ControlFlow::Continue
                     } else {
                         gtk::glib::ControlFlow::Break
                     };
                 }
-                // Floating first: a tiled window has no position of
-                // its own to set. Then pinned, so it stays put as you
-                // move between workspaces, which is most of what a pin
-                // is for.
-                hypr_dispatch(&format!("hl.dsp.window.float({{ {} }})", pin_selector()));
-                hypr_dispatch(&format!("hl.dsp.window.pin({{ {} }})", pin_selector()));
-                place_in_slot(slot);
+                desktop.arrange(slot);
                 gtk::glib::ControlFlow::Break
             });
         });
@@ -190,7 +186,7 @@ pub fn open(image: &Pixbuf, actions: PinActions) -> Pin {
     // the pin brings its own edge rather than reading as a picture
     // lying loose on the desktop.
     let overlay = gtk::Overlay::new();
-    if on_hyprland() {
+    if desktop.places_windows() {
         overlay.set_child(Some(&picture));
     } else {
         let frame = gtk::Box::new(gtk::Orientation::Horizontal, 0);
@@ -298,13 +294,179 @@ fn pin_title() -> String {
     format!("{PIN_TITLE} {}", std::process::id())
 }
 
-/// Whether the compositor is Hyprland, and so whether the pin can ask
-/// to be floated, pinned and placed.
+/// The compositors this pin knows how to ask for placement.
 ///
-/// Everything gated on this is a nicety: without it the pin still
-/// opens, still drags, and still does everything its toolbar offers.
-fn on_hyprland() -> bool {
-    std::env::var_os("HYPRLAND_INSTANCE_SIGNATURE").is_some()
+/// Wayland has no protocol for a window to position itself — that is
+/// deliberate, and every corner-placed window on Wayland goes through
+/// compositor-specific IPC. So this is a short list rather than a
+/// capability check, and everything gated on it is a nicety: an
+/// unrecognised compositor still gets a pin that opens, drags, edits,
+/// copies and drags out. It just lands where the compositor decides.
+#[derive(Clone, Copy, PartialEq)]
+enum Desktop {
+    Hyprland,
+    Sway,
+    Unknown,
+}
+
+impl Desktop {
+    fn detect() -> Self {
+        if std::env::var_os("HYPRLAND_INSTANCE_SIGNATURE").is_some() {
+            Desktop::Hyprland
+        } else if std::env::var_os("SWAYSOCK").is_some() {
+            Desktop::Sway
+        } else {
+            Desktop::Unknown
+        }
+    }
+
+    fn places_windows(self) -> bool {
+        self != Desktop::Unknown
+    }
+
+    /// Float this pin, show it on every workspace, and put it in
+    /// `slot`.
+    ///
+    /// Floating first in both: a tiled window has no position of its
+    /// own to set.
+    fn arrange(self, slot: i32) {
+        let Some((screen_w, screen_h)) = self.screen_size() else {
+            return;
+        };
+        let (frame_w, frame_h) = pin_size();
+        let x = screen_w - EDGE_MARGIN - frame_w;
+        let y = screen_h - EDGE_MARGIN - frame_h - slot * pin_step();
+        match self {
+            Desktop::Hyprland => {
+                let selector = format!("window = \"title:^({})$\"", pin_title());
+                hypr_dispatch(&format!("hl.dsp.window.float({{ {selector} }})"));
+                hypr_dispatch(&format!("hl.dsp.window.pin({{ {selector} }})"));
+                hypr_dispatch(&format!(
+                    "hl.dsp.window.move({{ x = {x}, y = {y}, relative = false, {selector} }})"
+                ));
+            }
+            Desktop::Sway => {
+                sway_command(&format!(
+                    "[title=\"^{}$\"] floating enable, sticky enable, \
+                     move absolute position {x} {y}",
+                    pin_title()
+                ));
+            }
+            Desktop::Unknown => {}
+        }
+    }
+
+    /// The focused output's size in logical pixels.
+    fn screen_size(self) -> Option<(i32, i32)> {
+        match self {
+            Desktop::Hyprland => {
+                let monitor = crate::display::hyprland_focused_monitor()?;
+                // Hyprland reports device pixels; windows are placed
+                // in logical ones.
+                let scale = (monitor.scale as f64).max(0.0001);
+                Some((
+                    (monitor.width as f64 / scale).round() as i32,
+                    (monitor.height as f64 / scale).round() as i32,
+                ))
+            }
+            Desktop::Sway => {
+                let outputs: serde_json::Value =
+                    serde_json::from_str(&sway_query("get_outputs")?).ok()?;
+                let focused = outputs
+                    .as_array()?
+                    .iter()
+                    .find(|o| o.get("focused").and_then(|f| f.as_bool()) == Some(true))?;
+                // Sway's rect is already logical.
+                let rect = focused.get("rect")?;
+                Some((
+                    rect.get("width")?.as_i64()? as i32,
+                    rect.get("height")?.as_i64()? as i32,
+                ))
+            }
+            Desktop::Unknown => None,
+        }
+    }
+
+    /// Where every pin currently sits, in logical pixels.
+    fn pin_rects(self) -> Vec<(i32, i32, i32, i32)> {
+        match self {
+            Desktop::Hyprland => hyprland_pin_rects(),
+            Desktop::Sway => sway_pin_rects(),
+            Desktop::Unknown => Vec::new(),
+        }
+    }
+
+    /// Whether this pin's window has reached the compositor yet.
+    fn sees_pin(self) -> bool {
+        let listing = match self {
+            Desktop::Hyprland => {
+                let output = std::process::Command::new("hyprctl")
+                    .args(["-j", "clients"])
+                    .output()
+                    .ok();
+                output.map(|o| String::from_utf8_lossy(&o.stdout).into_owned())
+            }
+            Desktop::Sway => sway_query("get_tree"),
+            Desktop::Unknown => None,
+        };
+        listing.is_some_and(|text| text.contains(&pin_title()))
+    }
+}
+
+/// Run one sway command, best-effort.
+fn sway_command(command: &str) {
+    let _ = std::process::Command::new("swaymsg")
+        .arg(command)
+        .output();
+}
+
+/// Ask sway for one of its JSON trees.
+fn sway_query(kind: &str) -> Option<String> {
+    let output = std::process::Command::new("swaymsg")
+        .args(["-t", kind, "-r"])
+        .output()
+        .ok()?;
+    output.status.success().then(|| String::from_utf8_lossy(&output.stdout).into_owned())
+}
+
+/// Every pin in sway's tree, with its geometry.
+///
+/// The tree is nested, so this walks it: a floating pin hangs off a
+/// workspace's floating list rather than sitting beside the tiled
+/// windows.
+fn sway_pin_rects() -> Vec<(i32, i32, i32, i32)> {
+    let Some(text) = sway_query("get_tree") else {
+        return Vec::new();
+    };
+    let Ok(tree) = serde_json::from_str::<serde_json::Value>(&text) else {
+        return Vec::new();
+    };
+    let mut found = Vec::new();
+    let mut pending = vec![tree];
+    while let Some(node) = pending.pop() {
+        if node
+            .get("name")
+            .and_then(|n| n.as_str())
+            .is_some_and(|name| name.starts_with(PIN_TITLE))
+            && let Some(rect) = node.get("rect")
+        {
+            let field = |key: &str| rect.get(key)?.as_i64().map(|v| v as i32);
+            if let (Some(x), Some(y), Some(w), Some(h)) = (
+                field("x"),
+                field("y"),
+                field("width"),
+                field("height"),
+            ) {
+                found.push((x, y, w, h));
+            }
+        }
+        for key in ["nodes", "floating_nodes"] {
+            if let Some(children) = node.get(key).and_then(|c| c.as_array()) {
+                pending.extend(children.iter().cloned());
+            }
+        }
+    }
+    found
 }
 
 /// Run one Hyprland dispatcher, best-effort.
@@ -324,41 +486,6 @@ fn hypr_dispatch(expression: &str) {
         .arg("dispatch")
         .arg(expression)
         .output();
-}
-
-/// Whether the compositor has this pin's window yet.
-fn pin_window_exists() -> bool {
-    let Ok(output) = std::process::Command::new("hyprctl")
-        .args(["-j", "clients"])
-        .output()
-    else {
-        return false;
-    };
-    String::from_utf8_lossy(&output.stdout).contains(&pin_title())
-}
-
-/// How a dispatcher names this pin, and only this pin.
-fn pin_selector() -> String {
-    format!("window = \"title:^({})$\"", pin_title())
-}
-
-/// Put the pin in `slot`, counting up from the bottom-right corner.
-fn place_in_slot(slot: i32) {
-    let Some(monitor) = crate::display::hyprland_focused_monitor() else {
-        return;
-    };
-    let scale = (monitor.scale as f64).max(0.0001);
-    let (screen_w, screen_h) = (
-        (monitor.width as f64 / scale).round() as i32,
-        (monitor.height as f64 / scale).round() as i32,
-    );
-    let (frame_w, frame_h) = pin_size();
-    let x = screen_w - EDGE_MARGIN - frame_w;
-    let y = screen_h - EDGE_MARGIN - frame_h - slot * pin_step();
-    hypr_dispatch(&format!(
-        "hl.dsp.window.move({{ x = {x}, y = {y}, relative = false, {} }})",
-        pin_selector()
-    ));
 }
 
 /// How far apart stacked pins sit, centre to centre.
@@ -402,31 +529,33 @@ fn first_free_slot(occupied: &[i32]) -> i32 {
 /// tell a pin that has been dragged away from one that hasn't. A
 /// compositor that can't be asked answers zero, and the new pin lands
 /// in the corner like the first one.
-fn next_slot() -> i32 {
+fn next_slot(desktop: Desktop) -> i32 {
+    let Some(screen) = desktop.screen_size() else {
+        return 0;
+    };
+    let occupied: Vec<i32> = desktop
+        .pin_rects()
+        .into_iter()
+        .filter_map(|rect| slot_of(rect, screen))
+        .collect();
+    first_free_slot(&occupied)
+}
+
+/// Every pin Hyprland knows about, with its geometry.
+fn hyprland_pin_rects() -> Vec<(i32, i32, i32, i32)> {
     let Ok(output) = std::process::Command::new("hyprctl")
         .args(["-j", "clients"])
         .output()
     else {
-        return 0;
+        return Vec::new();
     };
     let Ok(text) = String::from_utf8(output.stdout) else {
-        return 0;
+        return Vec::new();
     };
     let Ok(clients) = serde_json::from_str::<serde_json::Value>(&text) else {
-        return 0;
+        return Vec::new();
     };
-    let Some(monitor) = crate::display::hyprland_focused_monitor() else {
-        return 0;
-    };
-    // The monitor reports device pixels; windows are placed in logical
-    // ones.
-    let scale = (monitor.scale as f64).max(0.0001);
-    let screen = (
-        (monitor.width as f64 / scale).round() as i32,
-        (monitor.height as f64 / scale).round() as i32,
-    );
-
-    let occupied: Vec<i32> = clients
+    clients
         .as_array()
         .into_iter()
         .flatten()
@@ -445,9 +574,7 @@ fn next_slot() -> i32 {
             let (w, h) = pair("size")?;
             Some((x, y, w, h))
         })
-        .filter_map(|rect| slot_of(rect, screen))
-        .collect();
-    first_free_slot(&occupied)
+        .collect()
 }
 
 /// A square thumbnail of `image` that fills `side` and centre-crops,


### PR DESCRIPTION



## 🤖 New release

* `tensaku_cli`: 0.26.7 -> 0.27.0 (⚠ API breaking changes)
* `tensaku`: 0.26.7 -> 0.27.0

### ⚠ `tensaku_cli` breaking changes

```text
--- failure constructible_struct_adds_field: externally-constructible struct adds field ---

Description:
A pub struct constructible with a struct literal has a new pub field. Existing struct literals must be updated to include the new field.
        ref: https://doc.rust-lang.org/reference/expressions/struct-expr.html
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.48.0/src/lints/constructible_struct_adds_field.ron

Failed in:
  field CommandLine.capture in /tmp/.tmphkhksp/tensaku/cli/src/command_line.rs:67
```

<details><summary><i><b>Changelog</b></i></summary><p>


## `tensaku`

<blockquote>

## [0.27.0](https://github.com/jondkinney/tensaku/compare/v0.26.7...v0.27.0) - 2026-08-21

### Added

- *(pin)* place and stack pins on sway too
- *(pin)* degrade gracefully off Hyprland
- *(pin)* shape the pin like the display
- *(pin,capture)* square stacked pins, click-to-edit, untitled names
- *(capture)* the size pill takes the shot, and the puck matches
- *(capture)* a shutter button beside the restored region's puck
- *(capture)* the cursor says what a restored region will do
- *(capture)* grips and a move puck on a restored region
- *(capture)* adjust a restored region, and hide its measurement
- *(capture)* R restores the last region
- *(capture)* show the selection's pixel size while dragging
- *(scroll-capture)* the same pointer guides as the area capture
- *(capture)* A switches scrolling capture back to a normal one
- *(capture)* crosshair guides before the drag starts
- *(capture)* own the region selection, with window and mode switching
- *(pin)* tooltips, copy confirmations, and drag-out
- *(pin)* copy path saves the shot when it has none
- *(canvas)* the plain wheel walks whichever axis overflows
- *(pin)* pin the finished shot to the desktop
- *(spotlight)* Alt+wheel adjusts the loupe
- *(spotlight)* a magnification slider turns a spotlight into a loupe
- *(text)* an outlined style that reads over anything
- *(blur)* a Secure checkbox states what each mode can undo
- *(shapes)* f toggles fill on any fillable selection
- *(shapes)* a single r / e toggles a selected shape's fill
- *(canvas)* right-click an annotation to restack it
- *(stacking)* text lands above artwork, counters above text
- *(pointer)* plain wheel zooms when the Pointer is armed
- *(prefs)* remove the invert-scrolling preference
- *(canvas)* plain wheel sizes the next annotation
- *(counter)* preview the badge on the canvas, not in the cursor
- *(counter)* the cursor previews the badge it will stamp
- *(counter)* stamp the counter over text instead of grabbing it
- *(shapes)* shape tool buttons show their own fill, and widen the double-tap
- *(shapes)* double-tap a shape's key to toggle its fill, replacing F
- *(selection)* grab large annotations by their border, draw in their interior

### Fixed

- *(pin)* crop the preview to the capture's top, not its middle
- *(pin)* drop the mat and the rounded corner
- *(pin)* float, pin and place through the Lua dispatch API
- *(pin)* tooltips use the app's own, and the drag polls twice a frame
- *(pin)* the drag follows the pointer itself
- *(pin)* drag follows the pointer, and tooltips get out of the way
- *(pin)* slots follow where pins are, and moving one keeps up
- *(capture)* the shutter pill and puck carry their own cursors
- *(pin)* copy works, preview shows the shot, pins stack
- *(capture)* puck back to centre, size and shutter parked beneath it
- *(capture)* size readouts agree with the editor
- *(scroll-capture)* stop spawning hyprctl on every drag event
- *(capture)* hints along the bottom, not across the middle
- *(capture)* don't capture the overlay you just switched away from
- *(scroll-capture)* dim to the same weight as the area capture
- *(capture)* the area overlay wears the scroll capture's pill
- *(capture)* centre the area overlay's hint like the scroll one
- *(text)* the outline is white, like CleanShot X
- *(capture)* crosshair pointer while aiming a region
- *(capture)* cache the backdrop; stop toasting the saved text style
- *(capture)* take the picture before the overlay exists
- *(capture)* let the overlay leave the screen before capturing it
- *(capture)* merge the --capture flag into the configuration
- *(pin)* back every pin with a file so the drag carries a path
- *(pin)* drag a thumbnail, not the whole capture
- *(pin)* ask where to save when nothing is configured
- *(pin)* render the pixels the pin needs
- *(text)* Ctrl+Shift+wheel reaches the outlined style
- *(spotlight)* make magnification global, like darkness
- *(spotlight)* render the loupe in the pass that renders spotlights
- *(blur)* stop the secure blur seeding itself from its own glow
- *(blur)* put Secure beside the picker, not inside it
- *(ellipse)* grab the curve, not the box around it
- *(picking)* size the border-grab band in screen pixels
- *(shapes)* apply the r / e fill toggle instead of dropping it
- *(canvas)* stop inverting the compositor's scroll delta
- *(counter)* tighten the badge's lead on the pointer
- *(counter)* system cursor, offset badge
- *(counter)* move the pointer off the number it previews
- *(counter)* the cursor over text matches what the click does
- *(shapes)* keep each shape's fill toggle to that shape
- *(toolbar)* bundle the shape buttons' filled glyphs
- *(selection)* dismiss a selection before drawing inside a large annotation
- *(text)* clicking away from an in-progress text only ends it
- *(text)* grab an existing text box rather than stacking a new one on it
- *(input)* ignore modifiers left over from the launch chord
- *(arrow)* thicken only the tail when zoomed out
- *(canvas)* stop the expanded background showing a line per expansion
- *(omarchy)* opt out of default window opacity, wiring through Lua
- *(selection)* shrink the selection halo with the artwork when zoomed out
- *(canvas)* settle the edge extension away from the boundary
- *(canvas)* extend the image edge per line instead of one flat colour
- *(text)* wrap auto-fit text at the image edge while typing
- *(stitch)* keep a fixed edge's drop shadow out of every seam
- *(stitch)* crop viewport-fixed bands out of the motion search
- *(scroll-capture)* let the page inside a selected region take wheel and keys
- *(scroll-capture)* target the overlay's monitor for capture and pointer warps
- *(render)* tile the spotlight overlay past GL texture limits

### Other

- *(pin)* let the compositor move the pin
- *(pin)* lead the pointer by the latency instead of chasing it
- *(pin)* read the pointer off-thread, move on the frame clock
- *(capture)* composite the selection instead of painting it
- Revert "feat(pointer): plain wheel zooms when the Pointer is armed"
- drop the two removed preferences from the README
- *(canvas)* add probes for tile seams and flat-render uniformity
- *(canvas)* grow the raster by re-viewing it, not by copying it
- *(canvas)* add a grow-raster digest harness
- *(canvas)* reuse background textures across an auto-grow
- *(blur)* read back only the blurred region, and stop leaking textures
- *(canvas)* stop copying the raster twice on every re-upload
- *(canvas)* add an env-gated frame profiler
- update star history chart
- update star history chart
- update star history chart
- update star history chart
- *(stitch)* use is_multiple_of in the sparse-doc fixture
- *(stitch)* replay harness takes TENSAKU_STITCH_REPLAY_AXIS
- update star history chart
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).