### PR TITLE
chore: release v0.27.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,132 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.27.0](https://github.com/jondkinney/tensaku/compare/v0.26.7...v0.27.0) - 2026-08-21
+
+### Added
+
+- *(pin)* place and stack pins on sway too
+- *(pin)* degrade gracefully off Hyprland
+- *(pin)* shape the pin like the display
+- *(pin,capture)* square stacked pins, click-to-edit, untitled names
+- *(capture)* the size pill takes the shot, and the puck matches
+- *(capture)* a shutter button beside the restored region's puck
+- *(capture)* the cursor says what a restored region will do
+- *(capture)* grips and a move puck on a restored region
+- *(capture)* adjust a restored region, and hide its measurement
+- *(capture)* R restores the last region
+- *(capture)* show the selection's pixel size while dragging
+- *(scroll-capture)* the same pointer guides as the area capture
+- *(capture)* A switches scrolling capture back to a normal one
+- *(capture)* crosshair guides before the drag starts
+- *(capture)* own the region selection, with window and mode switching
+- *(pin)* tooltips, copy confirmations, and drag-out
+- *(pin)* copy path saves the shot when it has none
+- *(canvas)* the plain wheel walks whichever axis overflows
+- *(pin)* pin the finished shot to the desktop
+- *(spotlight)* Alt+wheel adjusts the loupe
+- *(spotlight)* a magnification slider turns a spotlight into a loupe
+- *(text)* an outlined style that reads over anything
+- *(blur)* a Secure checkbox states what each mode can undo
+- *(shapes)* f toggles fill on any fillable selection
+- *(shapes)* a single r / e toggles a selected shape's fill
+- *(canvas)* right-click an annotation to restack it
+- *(stacking)* text lands above artwork, counters above text
+- *(pointer)* plain wheel zooms when the Pointer is armed
+- *(prefs)* remove the invert-scrolling preference
+- *(canvas)* plain wheel sizes the next annotation
+- *(counter)* preview the badge on the canvas, not in the cursor
+- *(counter)* the cursor previews the badge it will stamp
+- *(counter)* stamp the counter over text instead of grabbing it
+- *(shapes)* shape tool buttons show their own fill, and widen the double-tap
+- *(shapes)* double-tap a shape's key to toggle its fill, replacing F
+- *(selection)* grab large annotations by their border, draw in their interior
+
+### Fixed
+
+- *(pin)* crop the preview to the capture's top, not its middle
+- *(pin)* drop the mat and the rounded corner
+- *(pin)* float, pin and place through the Lua dispatch API
+- *(pin)* tooltips use the app's own, and the drag polls twice a frame
+- *(pin)* the drag follows the pointer itself
+- *(pin)* drag follows the pointer, and tooltips get out of the way
+- *(pin)* slots follow where pins are, and moving one keeps up
+- *(capture)* the shutter pill and puck carry their own cursors
+- *(pin)* copy works, preview shows the shot, pins stack
+- *(capture)* puck back to centre, size and shutter parked beneath it
+- *(capture)* size readouts agree with the editor
+- *(scroll-capture)* stop spawning hyprctl on every drag event
+- *(capture)* hints along the bottom, not across the middle
+- *(capture)* don't capture the overlay you just switched away from
+- *(scroll-capture)* dim to the same weight as the area capture
+- *(capture)* the area overlay wears the scroll capture's pill
+- *(capture)* centre the area overlay's hint like the scroll one
+- *(text)* the outline is white, like CleanShot X
+- *(capture)* crosshair pointer while aiming a region
+- *(capture)* cache the backdrop; stop toasting the saved text style
+- *(capture)* take the picture before the overlay exists
+- *(capture)* let the overlay leave the screen before capturing it
+- *(capture)* merge the --capture flag into the configuration
+- *(pin)* back every pin with a file so the drag carries a path
+- *(pin)* drag a thumbnail, not the whole capture
+- *(pin)* ask where to save when nothing is configured
+- *(pin)* render the pixels the pin needs
+- *(text)* Ctrl+Shift+wheel reaches the outlined style
+- *(spotlight)* make magnification global, like darkness
+- *(spotlight)* render the loupe in the pass that renders spotlights
+- *(blur)* stop the secure blur seeding itself from its own glow
+- *(blur)* put Secure beside the picker, not inside it
+- *(ellipse)* grab the curve, not the box around it
+- *(picking)* size the border-grab band in screen pixels
+- *(shapes)* apply the r / e fill toggle instead of dropping it
+- *(canvas)* stop inverting the compositor's scroll delta
+- *(counter)* tighten the badge's lead on the pointer
+- *(counter)* system cursor, offset badge
+- *(counter)* move the pointer off the number it previews
+- *(counter)* the cursor over text matches what the click does
+- *(shapes)* keep each shape's fill toggle to that shape
+- *(toolbar)* bundle the shape buttons' filled glyphs
+- *(selection)* dismiss a selection before drawing inside a large annotation
+- *(text)* clicking away from an in-progress text only ends it
+- *(text)* grab an existing text box rather than stacking a new one on it
+- *(input)* ignore modifiers left over from the launch chord
+- *(arrow)* thicken only the tail when zoomed out
+- *(canvas)* stop the expanded background showing a line per expansion
+- *(omarchy)* opt out of default window opacity, wiring through Lua
+- *(selection)* shrink the selection halo with the artwork when zoomed out
+- *(canvas)* settle the edge extension away from the boundary
+- *(canvas)* extend the image edge per line instead of one flat colour
+- *(text)* wrap auto-fit text at the image edge while typing
+- *(stitch)* keep a fixed edge's drop shadow out of every seam
+- *(stitch)* crop viewport-fixed bands out of the motion search
+- *(scroll-capture)* let the page inside a selected region take wheel and keys
+- *(scroll-capture)* target the overlay's monitor for capture and pointer warps
+- *(render)* tile the spotlight overlay past GL texture limits
+
+### Other
+
+- *(region-capture)* run cargo fmt
+- *(pin)* let the compositor move the pin
+- *(pin)* lead the pointer by the latency instead of chasing it
+- *(pin)* read the pointer off-thread, move on the frame clock
+- *(capture)* composite the selection instead of painting it
+- Revert "feat(pointer): plain wheel zooms when the Pointer is armed"
+- drop the two removed preferences from the README
+- *(canvas)* add probes for tile seams and flat-render uniformity
+- *(canvas)* grow the raster by re-viewing it, not by copying it
+- *(canvas)* add a grow-raster digest harness
+- *(canvas)* reuse background textures across an auto-grow
+- *(blur)* read back only the blurred region, and stop leaking textures
+- *(canvas)* stop copying the raster twice on every re-upload
+- *(canvas)* add an env-gated frame profiler
+- update star history chart
+- update star history chart
+- update star history chart
+- update star history chart
+- *(stitch)* use is_multiple_of in the sparse-doc fixture
+- *(stitch)* replay harness takes TENSAKU_STITCH_REPLAY_AXIS
+- update star history chart
+
 ## [0.26.7](https://github.com/jondkinney/tensaku/compare/v0.26.6...v0.26.7) - 2026-08-15
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1761,7 +1761,7 @@ checksum = "df7f62577c25e07834649fc3b39fafdc597c0a3527dc1c60129201ccfcbaa50c"
 
 [[package]]
 name = "tensaku"
-version = "0.26.7"
+version = "0.27.0"
 dependencies = [
  "anyhow",
  "chrono",
@@ -1802,7 +1802,7 @@ dependencies = [
 
 [[package]]
 name = "tensaku_cli"
-version = "0.26.7"
+version = "0.27.0"
 dependencies = [
  "clap",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -88,7 +88,7 @@ clap_mangen = "0.3.0"
 members = [ "cli" ]
 
 [workspace.package]
-version = "0.26.7"
+version = "0.27.0"
 edition = "2024"
 # Tensaku is a fork of Satty; Matthias Gabriel is retained as the
 # original author per the MPL-2.0 (see NOTICE).
@@ -100,5 +100,5 @@ license = "MPL-2.0"
 
 [workspace.dependencies]
 clap = { version = "4.6.1", features = ["derive"] }
-tensaku_cli = { path = "cli", version = "0.26.7" }
+tensaku_cli = { path = "cli", version = "0.27.0" }
 serde = { version = "1.0", features = ["derive"] }

--- a/build.rs
+++ b/build.rs
@@ -107,6 +107,8 @@ fn main() -> Result<(), io::Error> {
             // The pin's drag-out handle: six dots, the same shape file
             // managers use for "pick this up and take it somewhere".
             "re-order-dots-horizontal-regular",
+            // The capture button on a restored region.
+            "camera-regular",
             // (The arrow-style picker uses cairo-drawn previews
             // matching the real arrow shapes; no icons needed.)
             // Layer-panel toggle button (F7).

--- a/packaging/aur/PKGBUILD
+++ b/packaging/aur/PKGBUILD
@@ -14,6 +14,11 @@ url='https://github.com/jondkinney/tensaku'
 license=('MPL-2.0')
 depends=('gtk4' 'gtk4-layer-shell' 'libadwaita' 'libepoxy' 'fontconfig')
 makedepends=('rust')
+# Window snapping and pin placement ask the compositor where its
+# windows are; without its CLI you drag the region by hand and the
+# pin lands wherever the compositor puts it. Neither is required.
+optdepends=('hyprland: window snapping and pin placement'
+            'sway: window snapping and pin placement')
 source=("$pkgname-$pkgver.tar.gz::$url/archive/refs/tags/v$pkgver.tar.gz")
 sha256sums=('52762f03a109afa1749e941d2ce2ba9e1956e4fd1975347c0cd92ddfb6e35968')
 

--- a/src/assets/default.css
+++ b/src/assets/default.css
@@ -538,17 +538,9 @@ dropdown.compact-control > button.combo {
   background: transparent;
 }
 
-/* The compositor draws the border and the shadow around a floating
-   window, so this is only the mat the picture sits on. Two frames
-   around one picture is one frame too many. */
-.pin-frame {
-  background: rgba(28, 28, 30, 0.94);
-  padding: 6px;
-}
-
-.pin-window picture {
-  border-radius: 7px;
-}
+/* Nothing around the picture: the compositor draws the border and the
+   shadow around a floating window, and a mat or a rounded corner of
+   our own would be a second frame inside the first. */
 
 .pin-controls {
   background: rgba(0, 0, 0, 0.55);

--- a/src/assets/default.css
+++ b/src/assets/default.css
@@ -538,9 +538,21 @@ dropdown.compact-control > button.combo {
   background: transparent;
 }
 
-/* Nothing around the picture: the compositor draws the border and the
-   shadow around a floating window, and a mat or a rounded corner of
-   our own would be a second frame inside the first. */
+/* Only used off Hyprland. There, the compositor draws the border and
+   the shadow around a floating window and a mat of our own would be a
+   second frame inside the first; elsewhere there is no promise of one
+   around an undecorated window, so the pin brings its own. */
+.pin-frame {
+  background: rgba(28, 28, 30, 0.94);
+  border: 1px solid rgba(255, 255, 255, 0.10);
+  border-radius: 12px;
+  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.55);
+  padding: 6px;
+}
+
+.pin-frame picture {
+  border-radius: 7px;
+}
 
 .pin-controls {
   background: rgba(0, 0, 0, 0.55);

--- a/src/assets/default.css
+++ b/src/assets/default.css
@@ -538,13 +538,11 @@ dropdown.compact-control > button.combo {
   background: transparent;
 }
 
-/* A frame of its own: the pin needs an edge or it reads as a picture
-   lying loose on the desktop rather than a thing sitting on it. */
+/* The compositor draws the border and the shadow around a floating
+   window, so this is only the mat the picture sits on. Two frames
+   around one picture is one frame too many. */
 .pin-frame {
   background: rgba(28, 28, 30, 0.94);
-  border: 1px solid rgba(255, 255, 255, 0.10);
-  border-radius: 12px;
-  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.55);
   padding: 6px;
 }
 

--- a/src/assets/default.css
+++ b/src/assets/default.css
@@ -538,8 +538,18 @@ dropdown.compact-control > button.combo {
   background: transparent;
 }
 
+/* A frame of its own: the pin needs an edge or it reads as a picture
+   lying loose on the desktop rather than a thing sitting on it. */
+.pin-frame {
+  background: rgba(28, 28, 30, 0.94);
+  border: 1px solid rgba(255, 255, 255, 0.10);
+  border-radius: 12px;
+  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.55);
+  padding: 6px;
+}
+
 .pin-window picture {
-  border-radius: 10px;
+  border-radius: 7px;
 }
 
 .pin-controls {

--- a/src/hypr.rs
+++ b/src/hypr.rs
@@ -68,6 +68,41 @@ pub fn resize_self(w: i32, h: i32) -> bool {
         .any(|cmd| paths.iter().any(|path| dispatch_ok(path, cmd)))
 }
 
+/// Where the pointer is, in logical screen coordinates.
+///
+/// Over the IPC socket rather than by spawning `hyprctl`: this is
+/// asked on a timer while a pin is being dragged, and a fork per frame
+/// is what made an earlier drag unusable. A socket round-trip is
+/// sub-millisecond and bounded by [`IPC_TIMEOUT`].
+///
+/// The pointer is the one thing a moving window cannot disturb, which
+/// is why a drag follows it rather than a gesture's own deltas: those
+/// are measured inside the window being moved.
+pub fn cursor_position() -> Option<(i32, i32)> {
+    let sig = std::env::var_os("HYPRLAND_INSTANCE_SIGNATURE")?;
+    let sig = sig.to_string_lossy();
+    socket_paths(&sig)
+        .iter()
+        .find_map(|path| parse_cursor_position(&request(path, "cursorpos")?))
+}
+
+/// `cursorpos` answers `x, y`.
+fn parse_cursor_position(reply: &str) -> Option<(i32, i32)> {
+    let (x, y) = reply.trim().split_once(',')?;
+    Some((x.trim().parse().ok()?, y.trim().parse().ok()?))
+}
+
+/// Send one IPC command and return its reply.
+fn request(path: &str, cmd: &str) -> Option<String> {
+    let mut stream = UnixStream::connect(path).ok()?;
+    let _ = stream.set_write_timeout(Some(IPC_TIMEOUT));
+    let _ = stream.set_read_timeout(Some(IPC_TIMEOUT));
+    stream.write_all(cmd.as_bytes()).ok()?;
+    let mut reply = String::new();
+    stream.read_to_string(&mut reply).ok()?;
+    Some(reply)
+}
+
 /// Candidate IPC socket paths, newest layout first. Hyprland ≥ 0.40 keeps the
 /// socket under `$XDG_RUNTIME_DIR/hypr/<sig>/`; older builds used `/tmp/hypr/`.
 fn socket_paths(sig: &str) -> Vec<String> {
@@ -94,4 +129,23 @@ fn dispatch_ok(path: &str, cmd: &str) -> bool {
     let mut resp = String::new();
     let _ = stream.read_to_string(&mut resp);
     resp.trim() == "ok"
+}
+
+#[cfg(test)]
+mod tests {
+    use super::parse_cursor_position;
+
+    #[test]
+    fn a_cursor_reply_parses() {
+        assert_eq!(parse_cursor_position("640, 480"), Some((640, 480)));
+        assert_eq!(parse_cursor_position("0,0\n"), Some((0, 0)));
+    }
+
+    /// A compositor that answers something else leaves the pin where
+    /// it is rather than throwing it to the corner.
+    #[test]
+    fn a_strange_reply_is_no_position() {
+        assert_eq!(parse_cursor_position("unknown request"), None);
+        assert_eq!(parse_cursor_position(""), None);
+    }
 }

--- a/src/hypr.rs
+++ b/src/hypr.rs
@@ -68,41 +68,6 @@ pub fn resize_self(w: i32, h: i32) -> bool {
         .any(|cmd| paths.iter().any(|path| dispatch_ok(path, cmd)))
 }
 
-/// Where the pointer is, in logical screen coordinates.
-///
-/// Over the IPC socket rather than by spawning `hyprctl`: this is
-/// asked on a timer while a pin is being dragged, and a fork per frame
-/// is what made an earlier drag unusable. A socket round-trip is
-/// sub-millisecond and bounded by [`IPC_TIMEOUT`].
-///
-/// The pointer is the one thing a moving window cannot disturb, which
-/// is why a drag follows it rather than a gesture's own deltas: those
-/// are measured inside the window being moved.
-pub fn cursor_position() -> Option<(i32, i32)> {
-    let sig = std::env::var_os("HYPRLAND_INSTANCE_SIGNATURE")?;
-    let sig = sig.to_string_lossy();
-    socket_paths(&sig)
-        .iter()
-        .find_map(|path| parse_cursor_position(&request(path, "cursorpos")?))
-}
-
-/// `cursorpos` answers `x, y`.
-fn parse_cursor_position(reply: &str) -> Option<(i32, i32)> {
-    let (x, y) = reply.trim().split_once(',')?;
-    Some((x.trim().parse().ok()?, y.trim().parse().ok()?))
-}
-
-/// Send one IPC command and return its reply.
-fn request(path: &str, cmd: &str) -> Option<String> {
-    let mut stream = UnixStream::connect(path).ok()?;
-    let _ = stream.set_write_timeout(Some(IPC_TIMEOUT));
-    let _ = stream.set_read_timeout(Some(IPC_TIMEOUT));
-    stream.write_all(cmd.as_bytes()).ok()?;
-    let mut reply = String::new();
-    stream.read_to_string(&mut reply).ok()?;
-    Some(reply)
-}
-
 /// Candidate IPC socket paths, newest layout first. Hyprland ≥ 0.40 keeps the
 /// socket under `$XDG_RUNTIME_DIR/hypr/<sig>/`; older builds used `/tmp/hypr/`.
 fn socket_paths(sig: &str) -> Vec<String> {
@@ -129,23 +94,4 @@ fn dispatch_ok(path: &str, cmd: &str) -> bool {
     let mut resp = String::new();
     let _ = stream.read_to_string(&mut resp);
     resp.trim() == "ok"
-}
-
-#[cfg(test)]
-mod tests {
-    use super::parse_cursor_position;
-
-    #[test]
-    fn a_cursor_reply_parses() {
-        assert_eq!(parse_cursor_position("640, 480"), Some((640, 480)));
-        assert_eq!(parse_cursor_position("0,0\n"), Some((0, 0)));
-    }
-
-    /// A compositor that answers something else leaves the pin where
-    /// it is rather than throwing it to the corner.
-    #[test]
-    fn a_strange_reply_is_no_position() {
-        assert_eq!(parse_cursor_position("unknown request"), None);
-        assert_eq!(parse_cursor_position(""), None);
-    }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -2295,6 +2295,24 @@ fn run_region_capture() -> Result<()> {
 /// moment it does. Recursion would work until someone changed their
 /// mind twice.
 fn run_capture_flow(mut scrolling: bool) -> Result<()> {
+    /// After one overlay hands over to the other, wait this long
+    /// before capturing.
+    ///
+    /// The area overlay freezes the screen at startup, and the
+    /// compositor doesn't remove a layer surface the moment its
+    /// application exits — so a capture taken immediately after a
+    /// handover contains the previous overlay's dim, and the screen
+    /// ends up shaded twice. Measured: a single shade leaves 55% of
+    /// the original brightness, a doubled one 39%.
+    ///
+    /// A settle rather than a guarantee: the two overlays are separate
+    /// applications, so there is no frame callback spanning both to
+    /// wait on. It only costs anything on an explicit mode switch,
+    /// where a tenth of a second is invisible next to the keypress
+    /// that asked for it.
+    const HANDOVER_SETTLE: std::time::Duration = std::time::Duration::from_millis(150);
+    let mut handed_over = false;
+
     loop {
         if scrolling {
             let park_pointer = APP_CONFIG
@@ -2304,6 +2322,7 @@ fn run_capture_flow(mut scrolling: bool) -> Result<()> {
                 scroll_capture::ScrollRun::Cancelled => return Ok(()),
                 scroll_capture::ScrollRun::SwitchToArea => {
                     scrolling = false;
+                    handed_over = true;
                     continue;
                 }
                 scroll_capture::ScrollRun::Captured(outcome) => {
@@ -2313,6 +2332,9 @@ fn run_capture_flow(mut scrolling: bool) -> Result<()> {
             }
         }
 
+        if std::mem::take(&mut handed_over) {
+            std::thread::sleep(HANDOVER_SETTLE);
+        }
         let output = crate::display::hyprland_focused_monitor().map(|m| m.name);
         // Take the picture BEFORE the overlay exists. Capturing
         // afterwards means racing the compositor to unmap a layer
@@ -2329,6 +2351,7 @@ fn run_capture_flow(mut scrolling: bool) -> Result<()> {
             }
             region_capture::RegionOutcome::Scroll => {
                 scrolling = true;
+                handed_over = true;
                 continue;
             }
         };

--- a/src/main.rs
+++ b/src/main.rs
@@ -2284,34 +2284,57 @@ fn start_gui(image: Pixbuf) -> Result<()> {
 /// capture free: at the moment of the switch, nothing has been
 /// captured yet.
 fn run_region_capture() -> Result<()> {
-    let output = crate::display::hyprland_focused_monitor().map(|m| m.name);
-    // Take the picture BEFORE the overlay exists. Capturing afterwards
-    // means racing the compositor to unmap a layer surface, and losing
-    // that race puts the selection UI in the screenshot.
-    let frozen = capture::capture_output(output.as_deref())?;
-    let image = match region_capture::run(frozen.clone())? {
-        region_capture::RegionOutcome::Cancelled => return Ok(()),
-        region_capture::RegionOutcome::Fullscreen => frozen,
-        region_capture::RegionOutcome::Region(rect) => {
-            // Already in the capture's own pixels, so this is a crop
-            // rather than a second trip to the compositor.
-            frozen.new_subpixbuf(rect.x, rect.y, rect.width, rect.height)
-        }
-        region_capture::RegionOutcome::Scroll => {
+    run_capture_flow(false)
+}
+
+/// Choose what to capture, take it, and open the editor on it.
+///
+/// A loop rather than two functions calling each other, because each
+/// overlay can hand over to the other -- S from the area overlay, A
+/// from the scrolling one -- and neither has captured anything at the
+/// moment it does. Recursion would work until someone changed their
+/// mind twice.
+fn run_capture_flow(mut scrolling: bool) -> Result<()> {
+    loop {
+        if scrolling {
             let park_pointer = APP_CONFIG
                 .read()
                 .park_pointer_during_manual_scroll_capture();
-            return match scroll_capture::run(park_pointer)? {
-                None => Ok(()),
-                Some(outcome) => {
-                    load_gl()?;
-                    start_gui_with_toast(outcome.image, outcome.warning)
+            match scroll_capture::run(park_pointer)? {
+                scroll_capture::ScrollRun::Cancelled => return Ok(()),
+                scroll_capture::ScrollRun::SwitchToArea => {
+                    scrolling = false;
+                    continue;
                 }
-            };
+                scroll_capture::ScrollRun::Captured(outcome) => {
+                    load_gl()?;
+                    return start_gui_with_toast(outcome.image, outcome.warning);
+                }
+            }
         }
-    };
-    load_gl()?;
-    start_gui_with_toast(image, None)
+
+        let output = crate::display::hyprland_focused_monitor().map(|m| m.name);
+        // Take the picture BEFORE the overlay exists. Capturing
+        // afterwards means racing the compositor to unmap a layer
+        // surface, and losing that race puts the selection UI in the
+        // screenshot.
+        let frozen = capture::capture_output(output.as_deref())?;
+        let image = match region_capture::run(frozen.clone())? {
+            region_capture::RegionOutcome::Cancelled => return Ok(()),
+            region_capture::RegionOutcome::Fullscreen => frozen,
+            region_capture::RegionOutcome::Region(rect) => {
+                // Already in the capture's own pixels, so this is a
+                // crop rather than a second trip to the compositor.
+                frozen.new_subpixbuf(rect.x, rect.y, rect.width, rect.height)
+            }
+            region_capture::RegionOutcome::Scroll => {
+                scrolling = true;
+                continue;
+            }
+        };
+        load_gl()?;
+        return start_gui_with_toast(image, None);
+    }
 }
 
 fn start_gui_with_toast(image: Pixbuf, initial_toast: Option<String>) -> Result<()> {
@@ -2431,19 +2454,12 @@ fn main() -> Result<()> {
     }
 
     if APP_CONFIG.read().scroll_capture() {
-        let park_pointer = APP_CONFIG
-            .read()
-            .park_pointer_during_manual_scroll_capture();
-        return match scroll_capture::run(park_pointer) {
+        return match run_capture_flow(true) {
             Err(e) => {
                 eprintln!("Error: {e}");
                 Err(e)
             }
-            Ok(None) => Ok(()),
-            Ok(Some(outcome)) => {
-                load_gl()?;
-                start_gui_with_toast(outcome.image, outcome.warning)
-            }
+            ok => ok,
         };
     }
 

--- a/src/pin.rs
+++ b/src/pin.rs
@@ -20,12 +20,10 @@
 //!   cost is that the pin lasts as long as the process does.
 
 use crate::ui::toolbars::RobustTooltipExt;
-use gtk4_layer_shell::{Edge, KeyboardMode, Layer, LayerShell};
 use relm4::gtk::gdk_pixbuf::InterpType;
 use relm4::gtk::{self, gdk_pixbuf::Pixbuf, prelude::*};
-use std::cell::{Cell, RefCell};
-use std::sync::Arc;
-use std::sync::atomic::{AtomicBool, AtomicI32, Ordering};
+
+use std::cell::Cell;
 use std::rc::Rc;
 use std::time::Duration;
 
@@ -50,27 +48,6 @@ const MOVE_TOOLTIP: &str = "Move this pin";
 /// The preview's tooltip, hidden while a drag-out is in flight for the
 /// same reason.
 const PICTURE_TOOLTIP: &str = "Click to open in the editor · Drag into another app to paste it";
-
-/// How often the follower thread reads the pointer.
-///
-/// Far faster than a frame, because it costs nothing on the UI thread:
-/// whatever the compositor answers, the freshest reading is already
-/// waiting when the next frame asks for it.
-const POLL_INTERVAL: Duration = Duration::from_millis(2);
-
-/// How far ahead of the pointer to place a dragged pin. Measured: the
-/// pin lands about 12ms behind the pointer, and that is a frame of
-/// compositor work rather than anything this side can skip.
-const LEAD: Duration = Duration::from_millis(12);
-
-/// Most a lead may add, in pixels. Past a flick this fast the guess is
-/// worth less than the overshoot it causes.
-const LEAD_CAP: i32 = 48;
-
-/// How much of each reading folds into the smoothed speed. Low enough
-/// that a jittery hand doesn't throw the lead around, high enough that
-/// a change of direction is followed within a frame or two.
-const VELOCITY_BLEND: f32 = 0.35;
 
 /// Gap between stacked pins.
 const PIN_GAP: i32 = 12;
@@ -127,32 +104,27 @@ pub fn open(image: &Pixbuf, actions: PinActions) -> Pin {
     let window = gtk::Window::builder()
         .resizable(false)
         .decorated(false)
+        .title(PIN_TITLE)
         .build();
     window.add_css_class("pin-window");
 
-    window.init_layer_shell();
-    // Overlay, not Top: a pinned reference is meant to stay visible
-    // over whatever you switch to, which is the entire point of
-    // pinning it rather than leaving the editor open.
-    window.set_layer(Layer::Overlay);
-    window.set_anchor(Edge::Right, true);
-    window.set_anchor(Edge::Bottom, true);
-    window.set_namespace(Some(PIN_NAMESPACE));
-    // Stack above whatever is already pinned instead of landing on
-    // top of it. Each capture is its own process, so the count comes
-    // from the compositor rather than from a shared list.
-    // Every pin is the same square, so a slot is just an index —
-    // and the lowest free one, so a pin dragged out of the column
-    // leaves its place for the next.
-    let bottom = EDGE_MARGIN + next_slot() * pin_step();
-    window.set_margin(Edge::Right, EDGE_MARGIN);
-    window.set_margin(Edge::Bottom, bottom);
-    // OnDemand rather than Exclusive: the pin should never swallow the
-    // keystrokes of whatever the user is actually working in, but Esc
-    // has to reach it once it is clicked.
-    window.set_keyboard_mode(KeyboardMode::OnDemand);
-
     window.set_default_size(PIN_SIDE + PIN_PADDING * 2, PIN_SIDE + PIN_PADDING * 2);
+
+    // Float it, show it on every workspace, and put it in its slot —
+    // once it has a surface for the compositor to match on.
+    {
+        let slot = next_slot();
+        window.connect_map(move |_| {
+            for dispatch in [
+                format!("setfloating,title:^({PIN_TITLE})$"),
+                format!("pin,title:^({PIN_TITLE})$"),
+                format!("alterzorder top,title:^({PIN_TITLE})$"),
+            ] {
+                hypr_dispatch(&dispatch);
+            }
+            place_in_slot(slot);
+        });
+    }
 
     // Scale the pixels here rather than asking the widget to shrink
     // them. A `Picture`'s natural size is its image's, so a 6K capture
@@ -179,7 +151,7 @@ pub fn open(image: &Pixbuf, actions: PinActions) -> Pin {
         on_edit: Box::new(move || edit_for_controls()),
         ..actions
     };
-    let controls = build_controls(&window, bottom, actions);
+    let controls = build_controls(&window, actions);
     overlay.add_overlay(&controls);
 
     let (toast_label, toast) = build_toast();
@@ -252,8 +224,37 @@ fn build_toast() -> (gtk::Label, Toast) {
     (label, Rc::new(show))
 }
 
-/// Layer-surface namespace, so pins can count each other.
-const PIN_NAMESPACE: &str = "tensaku-pin";
+/// Window title, which is how the compositor is told which window to
+/// float, pin and place — and how pins recognise each other.
+const PIN_TITLE: &str = "Tensaku Pin";
+
+/// Run one Hyprland dispatcher, best-effort.
+///
+/// Dispatchers rather than window rules: rules have to exist before a
+/// window maps and live in the user's config, and a pin should not
+/// need either.
+fn hypr_dispatch(args: &str) {
+    let _ = std::process::Command::new("hyprctl")
+        .arg("dispatch")
+        .args(args.split(' '))
+        .output();
+}
+
+/// Put the pin in `slot`, counting up from the bottom-right corner.
+fn place_in_slot(slot: i32) {
+    let Some(monitor) = crate::display::hyprland_focused_monitor() else {
+        return;
+    };
+    let scale = (monitor.scale as f64).max(0.0001);
+    let (screen_w, screen_h) = (
+        (monitor.width as f64 / scale).round() as i32,
+        (monitor.height as f64 / scale).round() as i32,
+    );
+    let side = PIN_SIDE + PIN_PADDING * 2;
+    let x = screen_w - EDGE_MARGIN - side;
+    let y = screen_h - EDGE_MARGIN - side - slot * pin_step();
+    hypr_dispatch(&format!("movewindowpixel exact {x} {y},title:^({PIN_TITLE})$"));
+}
 
 /// How far apart stacked pins sit, centre to centre.
 fn pin_step() -> i32 {
@@ -290,15 +291,15 @@ fn first_free_slot(occupied: &[i32]) -> i32 {
 
 /// Which slot a new pin should take.
 ///
-/// Asks the compositor where the existing pins actually are, rather
-/// than keeping a count: every capture is a separate process, a file
-/// of slots would go stale the first time one crashed, and a count
-/// can't tell a pin that has been dragged away from one that hasn't.
-/// A compositor that can't be asked answers zero, and the new pin
-/// lands in the corner like the first one.
+/// Asks the compositor where the existing pins are, rather than
+/// keeping a count: every capture is a separate process, a file of
+/// slots would go stale the first time one crashed, and a count can't
+/// tell a pin that has been dragged away from one that hasn't. A
+/// compositor that can't be asked answers zero, and the new pin lands
+/// in the corner like the first one.
 fn next_slot() -> i32 {
     let Ok(output) = std::process::Command::new("hyprctl")
-        .args(["-j", "layers"])
+        .args(["-j", "clients"])
         .output()
     else {
         return 0;
@@ -306,32 +307,33 @@ fn next_slot() -> i32 {
     let Ok(text) = String::from_utf8(output.stdout) else {
         return 0;
     };
-    let Ok(json) = serde_json::from_str::<serde_json::Value>(&text) else {
+    let Ok(clients) = serde_json::from_str::<serde_json::Value>(&text) else {
         return 0;
     };
     let Some(monitor) = crate::display::hyprland_focused_monitor() else {
         return 0;
     };
-    // The monitor reports device pixels; layers are placed in logical
-    // ones, which is the space the margins are in too.
+    // The monitor reports device pixels; windows are placed in logical
+    // ones.
     let scale = (monitor.scale as f64).max(0.0001);
     let screen = (
         (monitor.width as f64 / scale).round() as i32,
         (monitor.height as f64 / scale).round() as i32,
     );
 
-    let occupied: Vec<i32> = json
-        .as_object()
+    let occupied: Vec<i32> = clients
+        .as_array()
         .into_iter()
-        .flat_map(|monitors| monitors.values())
-        .filter_map(|monitor| monitor.get("levels")?.as_object())
-        .flat_map(|levels| levels.values())
-        .filter_map(|layers| layers.as_array())
         .flatten()
-        .filter(|layer| layer.get("namespace").and_then(|n| n.as_str()) == Some(PIN_NAMESPACE))
-        .filter_map(|layer| {
-            let field = |key: &str| layer.get(key)?.as_i64().map(|v| v as i32);
-            Some((field("x")?, field("y")?, field("w")?, field("h")?))
+        .filter(|client| client.get("title").and_then(|t| t.as_str()) == Some(PIN_TITLE))
+        .filter_map(|client| {
+            let pair = |key: &str| {
+                let v = client.get(key)?.as_array()?;
+                Some((v.first()?.as_i64()? as i32, v.get(1)?.as_i64()? as i32))
+            };
+            let (x, y) = pair("at")?;
+            let (w, h) = pair("size")?;
+            Some((x, y, w, h))
         })
         .filter_map(|rect| slot_of(rect, screen))
         .collect();
@@ -360,7 +362,7 @@ fn cover_thumbnail(image: &Pixbuf, side: i32) -> Pixbuf {
 }
 
 /// The hover toolbar: edit, copy, copy path, close.
-fn build_controls(window: &gtk::Window, bottom_margin: i32, actions: PinActions) -> gtk::Box {
+fn build_controls(window: &gtk::Window, actions: PinActions) -> gtk::Box {
     let controls = gtk::Box::new(gtk::Orientation::Horizontal, 4);
     controls.add_css_class("pin-controls");
     controls.set_halign(gtk::Align::End);
@@ -395,7 +397,7 @@ fn build_controls(window: &gtk::Window, bottom_margin: i32, actions: PinActions)
     // a drag carries it into another app.
     let move_handle = button("re-order-dots-horizontal-regular", MOVE_TOOLTIP);
     move_handle.add_css_class("pin-drag-handle");
-    install_move(window, &move_handle, bottom_margin);
+    install_move(window, &move_handle);
     controls.append(&move_handle);
 
     let edit = button("pen-regular", "Edit again");
@@ -494,175 +496,46 @@ fn fit_within(width: i32, height: i32, max: i32) -> (i32, i32) {
 /// anchors are on the far edges, so a rightward drag *shrinks* the
 /// right margin. The margins are held here rather than read back
 /// because `LayerShell` exposes no getter for them.
-fn install_move(window: &gtk::Window, target: &gtk::Button, bottom_margin: i32) {
-    let right = Rc::new(Cell::new(EDGE_MARGIN));
-    let bottom = Rc::new(Cell::new(bottom_margin));
-
+fn install_move(window: &gtk::Window, target: &gtk::Button) {
     let press = gtk::GestureClick::new();
-    {
-        let window = window.clone();
-        let right = right.clone();
-        let bottom = bottom.clone();
-        press.connect_pressed(move |_, _, _, _| {
-            let Some(origin) = crate::hypr::cursor_position() else {
-                return;
-            };
-            let start = (right.get(), bottom.get());
-
-            // The pointer is read on a thread of its own. Asking for
-            // it inline stalled the UI thread for five milliseconds at
-            // the ninetieth percentile — the compositor answers slowly
-            // exactly when it is busy, which is precisely when we have
-            // just asked it to move a window. Off-thread, the answer
-            // is always waiting and never in the way.
-            let cursor = Arc::new(CursorFollow::new(origin));
-            {
-                let cursor = Arc::clone(&cursor);
-                std::thread::spawn(move || {
-                    let mut last = std::time::Instant::now();
-                    while cursor.following.load(Ordering::Relaxed) {
-                        if let Some((x, y)) = crate::hypr::cursor_position() {
-                            let now = std::time::Instant::now();
-                            cursor.sample(x, y, now.duration_since(last).as_secs_f32());
-                            last = now;
-                        }
-                        std::thread::sleep(POLL_INTERVAL);
-                    }
-                });
-            }
-
-            let right = right.clone();
-            let bottom = bottom.clone();
-            let cursor_for_tick = Arc::clone(&cursor);
-            // On the frame clock rather than a timer: a margin can
-            // only take effect on a frame, so setting it more often
-            // than that is work the compositor throws away, and
-            // setting it on any other cadence means landing a step
-            // late.
-            window.add_tick_callback(move |window, _| {
-                if !cursor_for_tick.following.load(Ordering::Relaxed) {
-                    crate::ui::toolbars::dismiss_active_tooltip();
-                    return gtk::glib::ControlFlow::Break;
-                }
-                // Every frame: the pointer never leaves the handle
-                // during a drag, so nothing else takes the tooltip
-                // down.
-                crate::ui::toolbars::dismiss_active_tooltip();
-
-                let (x, y) = cursor_for_tick.predicted();
-                // Anchored bottom-right, so moving right shrinks the
-                // right margin. Clamped so a pin can't be pushed off
-                // the edge it hangs from and out of reach.
-                let new_right = (start.0 - (x - origin.0)).max(0);
-                let new_bottom = (start.1 - (y - origin.1)).max(0);
-                if (new_right, new_bottom) != (right.get(), bottom.get()) {
-                    right.set(new_right);
-                    bottom.set(new_bottom);
-                    window.set_margin(Edge::Right, new_right);
-                    window.set_margin(Edge::Bottom, new_bottom);
-                }
-                gtk::glib::ControlFlow::Continue
-            });
-            // The gesture's own end, and a pointer that leaves without
-            // one — a compositor grab ending, the window outrunning the
-            // pointer — both have to stop the follow, or the pin
-            // chases the cursor forever.
-            let stop = Arc::clone(&cursor);
-            RELEASE.with(|slot| *slot.borrow_mut() = Some(stop));
-        });
-    }
-    {
-        press.connect_released(|_, _, _, _| stop_following());
-    }
-    {
-        let cancel = gtk::EventControllerMotion::new();
-        cancel.connect_leave(|_| stop_following());
-        target.add_controller(cancel);
-    }
+    let window = window.clone();
+    press.connect_pressed(move |gesture, _, x, y| {
+        // Hand the drag to the compositor. Hyprland moves a floating
+        // window during its own frame, with the client out of the
+        // loop, which is why dragging one feels instant and why every
+        // attempt to move this window ourselves trailed by a frame:
+        // a client-positioned surface cannot be anywhere but one round
+        // trip behind the pointer.
+        crate::ui::toolbars::dismiss_active_tooltip();
+        let Some(surface) = window.surface() else {
+            return;
+        };
+        let Ok(toplevel) = surface.downcast::<gtk::gdk::Toplevel>() else {
+            return;
+        };
+        let Some(device) = gesture.device() else {
+            return;
+        };
+        // The compositor wants the grab in surface coordinates; the
+        // gesture reports them relative to the handle it is on.
+        let (sx, sy) = target_origin(gesture).unwrap_or((0.0, 0.0));
+        toplevel.begin_move(
+            &device,
+            gesture.current_button() as i32,
+            sx + x,
+            sy + y,
+            gesture.current_event_time(),
+        );
+    });
     target.add_controller(press);
 }
 
-/// The pointer position a drag is following, shared with the thread
-/// that reads it.
-struct CursorFollow {
-    x: AtomicI32,
-    y: AtomicI32,
-    /// Pointer speed in pixels per second, smoothed. Used to place the
-    /// pin where the pointer will be when the frame lands rather than
-    /// where it was when the frame was built.
-    vx: AtomicI32,
-    vy: AtomicI32,
-    following: AtomicBool,
-}
-
-impl CursorFollow {
-    fn new(origin: (i32, i32)) -> Self {
-        Self {
-            x: AtomicI32::new(origin.0),
-            y: AtomicI32::new(origin.1),
-            vx: AtomicI32::new(0),
-            vy: AtomicI32::new(0),
-            following: AtomicBool::new(true),
-        }
-    }
-
-    /// Where the pointer will be `LEAD` from now, at its current
-    /// speed.
-    ///
-    /// Measured end to end, a pin lands about 12ms after the pointer
-    /// it is following: the compositor has to accept a new margin,
-    /// lay the surface out and present it, and that is a frame's work
-    /// however the margin got there. Leading by that much cancels it,
-    /// which is what turns "close behind" into "attached".
-    ///
-    /// Capped, because a lead is a guess: at a direction change the
-    /// guess is wrong, and a small wrong guess reads as softness while
-    /// a large one reads as the pin overshooting and snapping back.
-    fn predicted(&self) -> (i32, i32) {
-        let lead = LEAD.as_secs_f32();
-        let step = |v: &AtomicI32| {
-            ((v.load(Ordering::Relaxed) as f32 * lead).round() as i32).clamp(-LEAD_CAP, LEAD_CAP)
-        };
-        (
-            self.x.load(Ordering::Relaxed) + step(&self.vx),
-            self.y.load(Ordering::Relaxed) + step(&self.vy),
-        )
-    }
-
-    /// Record a reading and fold it into the smoothed speed.
-    fn sample(&self, x: i32, y: i32, dt: f32) {
-        if dt > 0.0 {
-            let blend = |old: &AtomicI32, delta: i32| {
-                let instant = delta as f32 / dt;
-                let previous = old.load(Ordering::Relaxed) as f32;
-                // A plain difference of two readings is mostly noise
-                // at this rate; the average of the recent past is what
-                // a hand is actually doing.
-                old.store(
-                    (previous * (1.0 - VELOCITY_BLEND) + instant * VELOCITY_BLEND).round() as i32,
-                    Ordering::Relaxed,
-                );
-            };
-            blend(&self.vx, x - self.x.load(Ordering::Relaxed));
-            blend(&self.vy, y - self.y.load(Ordering::Relaxed));
-        }
-        self.x.store(x, Ordering::Relaxed);
-        self.y.store(y, Ordering::Relaxed);
-    }
-}
-
-thread_local! {
-    /// The drag in progress, so a release or a stray leave can end it.
-    /// One pin per process, and one drag at a time within it.
-    static RELEASE: RefCell<Option<Arc<CursorFollow>>> = const { RefCell::new(None) };
-}
-
-fn stop_following() {
-    RELEASE.with(|slot| {
-        if let Some(cursor) = slot.borrow_mut().take() {
-            cursor.following.store(false, Ordering::Relaxed);
-        }
-    });
+/// Where the gesture's widget sits inside the window, so a press on it
+/// can be reported in the window's own coordinates.
+fn target_origin(gesture: &gtk::GestureClick) -> Option<(f64, f64)> {
+    let widget = gesture.widget()?;
+    let root = widget.root()?;
+    widget.translate_coordinates(&root, 0.0, 0.0)
 }
 
 #[cfg(test)]

--- a/src/pin.rs
+++ b/src/pin.rs
@@ -41,6 +41,14 @@ const PIN_SIDE: i32 = 168;
 /// sitting on it.
 const PIN_PADDING: i32 = 6;
 
+/// The move handle's tooltip, named because the drag hides it and has
+/// to put it back.
+const MOVE_TOOLTIP: &str = "Move this pin";
+
+/// The preview's tooltip, hidden while a drag-out is in flight for the
+/// same reason.
+const PICTURE_TOOLTIP: &str = "Click to open in the editor · Drag into another app to paste it";
+
 /// Gap between stacked pins.
 const PIN_GAP: i32 = 12;
 
@@ -170,9 +178,7 @@ pub fn open(image: &Pixbuf, actions: PinActions) -> Pin {
 
     // The picture is the shot: clicking it opens the shot, dragging it
     // carries the shot somewhere.
-    picture.set_tooltip_text(Some(
-        "Click to open in the editor · Drag into another app to paste it",
-    ));
+    picture.set_tooltip_text(Some(PICTURE_TOOLTIP));
     picture.set_cursor_from_name(Some("pointer"));
     install_drag_out(&picture, image, saved_path_for_drag);
     {
@@ -364,7 +370,7 @@ fn build_controls(window: &gtk::Window, bottom_margin: i32, actions: PinActions)
     // face trails the pointer instead of following it — and the
     // picture has better things to answer for: a click opens the shot,
     // a drag carries it into another app.
-    let move_handle = button("re-order-dots-horizontal-regular", "Move this pin");
+    let move_handle = button("re-order-dots-horizontal-regular", MOVE_TOOLTIP);
     move_handle.add_css_class("pin-drag-handle");
     install_move(window, &move_handle, bottom_margin);
     controls.append(&move_handle);
@@ -427,6 +433,17 @@ fn install_drag_out(handle: &gtk::Picture, image: &Pixbuf, saved_path: Option<St
             source.set_icon(Some(&icon), icon_w / 2, icon_h / 2);
         });
     }
+    {
+        // Same tooltip problem as the move handle: a drag-out leaves
+        // the pointer over a picture that is now carrying something,
+        // and the tooltip follows it around.
+        let handle_begin = handle.clone();
+        source.connect_drag_begin(move |_, _| handle_begin.set_has_tooltip(false));
+        let handle_end = handle.clone();
+        source.connect_drag_end(move |_, _, _| {
+            handle_end.set_tooltip_text(Some(PICTURE_TOOLTIP));
+        });
+    }
     handle.add_controller(source);
 }
 
@@ -463,39 +480,48 @@ fn fit_within(width: i32, height: i32, max: i32) -> (i32, i32) {
 /// right margin. The margins are held here rather than read back
 /// because `LayerShell` exposes no getter for them.
 fn install_move(window: &gtk::Window, target: &gtk::Button, bottom_margin: i32) {
-    // Gesture deltas arrive in logical pixels; layer-shell margins are
-    // applied in device ones. On a 2x display that made the pin travel
-    // half as far as the pointer, which reads as the window lagging
-    // rather than as a unit mismatch.
-    let scale = crate::display::hyprland_focused_monitor()
-        .map(|m| m.scale as f64)
-        .unwrap_or(1.0)
-        .max(0.0001);
     let right = Rc::new(Cell::new(EDGE_MARGIN));
     let bottom = Rc::new(Cell::new(bottom_margin));
-    let start = Rc::new(Cell::new((EDGE_MARGIN, bottom_margin)));
 
     let drag = gtk::GestureDrag::new();
     {
-        let right = right.clone();
-        let bottom = bottom.clone();
-        let start = start.clone();
-        drag.connect_drag_begin(move |_, _, _| start.set((right.get(), bottom.get())));
-    }
-    {
+        // A moving window can't be dragged from a fixed reference.
+        // The gesture measures its delta inside this window's own
+        // coordinates, so every step the window takes is subtracted
+        // from the next reading: applied against the position the drag
+        // started from, the window catches up, the delta falls back to
+        // zero, and it springs to where it began — which is the lag,
+        // and the shake.
+        //
+        // Applying each reading to the CURRENT position instead is
+        // self-correcting: moving the window zeroes the delta, so the
+        // next reading is exactly the new pointer motion and nothing
+        // else.
         let window = window.clone();
         let right = right.clone();
         let bottom = bottom.clone();
         drag.connect_drag_update(move |_, dx, dy| {
-            let (start_right, start_bottom) = start.get();
             // Clamped at zero so a drag can't push the pin off the
-            // screen edge it is anchored to and out of reach.
-            let new_right = (start_right - (dx * scale).round() as i32).max(0);
-            let new_bottom = (start_bottom - (dy * scale).round() as i32).max(0);
+            // edge it is anchored to and out of reach.
+            let new_right = (right.get() - dx.round() as i32).max(0);
+            let new_bottom = (bottom.get() - dy.round() as i32).max(0);
             right.set(new_right);
             bottom.set(new_bottom);
             window.set_margin(Edge::Right, new_right);
             window.set_margin(Edge::Bottom, new_bottom);
+        });
+    }
+    {
+        // The window slides out from under the pointer while dragging,
+        // which GTK reads as a fresh hover on every step: the tooltip
+        // pops back and jitters along beside the pin.
+        let target_begin = target.clone();
+        drag.connect_drag_begin(move |_, _, _| target_begin.set_has_tooltip(false));
+    }
+    {
+        let target_end = target.clone();
+        drag.connect_drag_end(move |_, _, _| {
+            target_end.set_tooltip_text(Some(MOVE_TOOLTIP));
         });
     }
     target.add_controller(drag);

--- a/src/pin.rs
+++ b/src/pin.rs
@@ -110,9 +110,10 @@ pub fn open(image: &Pixbuf, actions: PinActions) -> Pin {
     // Stack above whatever is already pinned instead of landing on
     // top of it. Each capture is its own process, so the count comes
     // from the compositor rather than from a shared list.
-    // Every pin is the same square, so each new one sits exactly one
-    // step above the last rather than needing anyone's height.
-    let bottom = EDGE_MARGIN + stacked_pins() * (PIN_SIDE + PIN_PADDING * 2 + PIN_GAP);
+    // Every pin is the same square, so a slot is just an index —
+    // and the lowest free one, so a pin dragged out of the column
+    // leaves its place for the next.
+    let bottom = EDGE_MARGIN + next_slot() * pin_step();
     window.set_margin(Edge::Right, EDGE_MARGIN);
     window.set_margin(Edge::Bottom, bottom);
     // OnDemand rather than Exclusive: the pin should never swallow the
@@ -147,7 +148,7 @@ pub fn open(image: &Pixbuf, actions: PinActions) -> Pin {
         on_edit: Box::new(move || edit_for_controls()),
         ..actions
     };
-    let controls = build_controls(&window, actions);
+    let controls = build_controls(&window, bottom, actions);
     overlay.add_overlay(&controls);
 
     let (toast_label, toast) = build_toast();
@@ -169,6 +170,10 @@ pub fn open(image: &Pixbuf, actions: PinActions) -> Pin {
 
     // The picture is the shot: clicking it opens the shot, dragging it
     // carries the shot somewhere.
+    picture.set_tooltip_text(Some(
+        "Click to open in the editor · Drag into another app to paste it",
+    ));
+    picture.set_cursor_from_name(Some("pointer"));
     install_drag_out(&picture, image, saved_path_for_drag);
     {
         let edit = edit_for_picture;
@@ -221,13 +226,48 @@ fn build_toast() -> (gtk::Label, Toast) {
 /// Layer-surface namespace, so pins can count each other.
 const PIN_NAMESPACE: &str = "tensaku-pin";
 
-/// How many pins are already on screen.
+/// How far apart stacked pins sit, centre to centre.
+fn pin_step() -> i32 {
+    PIN_SIDE + PIN_PADDING * 2 + PIN_GAP
+}
+
+/// The slot a pin at `rect` is sitting in, or `None` if it isn't in
+/// one — because it has been dragged somewhere else.
 ///
-/// Asks the compositor rather than keeping a count: every capture is a
-/// separate process, and a file of slots would go stale the first time
-/// one crashed. A compositor that can't be asked answers zero, and the
-/// new pin lands in the corner like the first one.
-fn stacked_pins() -> i32 {
+/// A moved pin gives its slot back. Counting pins instead would keep
+/// stacking above one that is no longer there, leaving a hole at the
+/// bottom of the column and pushing new pins off the top of the
+/// screen.
+fn slot_of(rect: (i32, i32, i32, i32), screen: (i32, i32)) -> Option<i32> {
+    /// A pin within a few pixels of a slot is in it: margins round to
+    /// integers and compositors report what they rounded to.
+    const TOLERANCE: i32 = 4;
+    let side = PIN_SIDE + PIN_PADDING * 2;
+    let (x, y, _, _) = rect;
+    if (x - (screen.0 - EDGE_MARGIN - side)).abs() > TOLERANCE {
+        return None;
+    }
+    let base = screen.1 - EDGE_MARGIN - side;
+    let step = pin_step();
+    let index = ((base - y) as f64 / step as f64).round() as i32;
+    let expected = base - index * step;
+    (index >= 0 && (y - expected).abs() <= TOLERANCE).then_some(index)
+}
+
+/// The lowest slot nothing is sitting in.
+fn first_free_slot(occupied: &[i32]) -> i32 {
+    (0..).find(|slot| !occupied.contains(slot)).unwrap_or(0)
+}
+
+/// Which slot a new pin should take.
+///
+/// Asks the compositor where the existing pins actually are, rather
+/// than keeping a count: every capture is a separate process, a file
+/// of slots would go stale the first time one crashed, and a count
+/// can't tell a pin that has been dragged away from one that hasn't.
+/// A compositor that can't be asked answers zero, and the new pin
+/// lands in the corner like the first one.
+fn next_slot() -> i32 {
     let Ok(output) = std::process::Command::new("hyprctl")
         .args(["-j", "layers"])
         .output()
@@ -237,7 +277,36 @@ fn stacked_pins() -> i32 {
     let Ok(text) = String::from_utf8(output.stdout) else {
         return 0;
     };
-    text.matches(PIN_NAMESPACE).count() as i32
+    let Ok(json) = serde_json::from_str::<serde_json::Value>(&text) else {
+        return 0;
+    };
+    let Some(monitor) = crate::display::hyprland_focused_monitor() else {
+        return 0;
+    };
+    // The monitor reports device pixels; layers are placed in logical
+    // ones, which is the space the margins are in too.
+    let scale = (monitor.scale as f64).max(0.0001);
+    let screen = (
+        (monitor.width as f64 / scale).round() as i32,
+        (monitor.height as f64 / scale).round() as i32,
+    );
+
+    let occupied: Vec<i32> = json
+        .as_object()
+        .into_iter()
+        .flat_map(|monitors| monitors.values())
+        .filter_map(|monitor| monitor.get("levels")?.as_object())
+        .flat_map(|levels| levels.values())
+        .filter_map(|layers| layers.as_array())
+        .flatten()
+        .filter(|layer| layer.get("namespace").and_then(|n| n.as_str()) == Some(PIN_NAMESPACE))
+        .filter_map(|layer| {
+            let field = |key: &str| layer.get(key)?.as_i64().map(|v| v as i32);
+            Some((field("x")?, field("y")?, field("w")?, field("h")?))
+        })
+        .filter_map(|rect| slot_of(rect, screen))
+        .collect();
+    first_free_slot(&occupied)
 }
 
 /// A square thumbnail of `image` that fills `side` and centre-crops,
@@ -262,7 +331,7 @@ fn cover_thumbnail(image: &Pixbuf, side: i32) -> Pixbuf {
 }
 
 /// The hover toolbar: edit, copy, copy path, close.
-fn build_controls(window: &gtk::Window, actions: PinActions) -> gtk::Box {
+fn build_controls(window: &gtk::Window, bottom_margin: i32, actions: PinActions) -> gtk::Box {
     let controls = gtk::Box::new(gtk::Orientation::Horizontal, 4);
     controls.add_css_class("pin-controls");
     controls.set_halign(gtk::Align::End);
@@ -297,7 +366,7 @@ fn build_controls(window: &gtk::Window, actions: PinActions) -> gtk::Box {
     // a drag carries it into another app.
     let move_handle = button("re-order-dots-horizontal-regular", "Move this pin");
     move_handle.add_css_class("pin-drag-handle");
-    install_move(window, &move_handle);
+    install_move(window, &move_handle, bottom_margin);
     controls.append(&move_handle);
 
     let edit = button("pen-regular", "Edit again");
@@ -393,10 +462,18 @@ fn fit_within(width: i32, height: i32, max: i32) -> (i32, i32) {
 /// anchors are on the far edges, so a rightward drag *shrinks* the
 /// right margin. The margins are held here rather than read back
 /// because `LayerShell` exposes no getter for them.
-fn install_move(window: &gtk::Window, target: &gtk::Button) {
+fn install_move(window: &gtk::Window, target: &gtk::Button, bottom_margin: i32) {
+    // Gesture deltas arrive in logical pixels; layer-shell margins are
+    // applied in device ones. On a 2x display that made the pin travel
+    // half as far as the pointer, which reads as the window lagging
+    // rather than as a unit mismatch.
+    let scale = crate::display::hyprland_focused_monitor()
+        .map(|m| m.scale as f64)
+        .unwrap_or(1.0)
+        .max(0.0001);
     let right = Rc::new(Cell::new(EDGE_MARGIN));
-    let bottom = Rc::new(Cell::new(EDGE_MARGIN));
-    let start = Rc::new(Cell::new((EDGE_MARGIN, EDGE_MARGIN)));
+    let bottom = Rc::new(Cell::new(bottom_margin));
+    let start = Rc::new(Cell::new((EDGE_MARGIN, bottom_margin)));
 
     let drag = gtk::GestureDrag::new();
     {
@@ -413,8 +490,8 @@ fn install_move(window: &gtk::Window, target: &gtk::Button) {
             let (start_right, start_bottom) = start.get();
             // Clamped at zero so a drag can't push the pin off the
             // screen edge it is anchored to and out of reach.
-            let new_right = (start_right - dx.round() as i32).max(0);
-            let new_bottom = (start_bottom - dy.round() as i32).max(0);
+            let new_right = (start_right - (dx * scale).round() as i32).max(0);
+            let new_bottom = (start_bottom - (dy * scale).round() as i32).max(0);
             right.set(new_right);
             bottom.set(new_bottom);
             window.set_margin(Edge::Right, new_right);
@@ -426,7 +503,10 @@ fn install_move(window: &gtk::Window, target: &gtk::Button) {
 
 #[cfg(test)]
 mod tests {
-    use super::{DRAG_ICON_MAX, PIN_GAP, PIN_PADDING, PIN_SIDE, cover_thumbnail, fit_within};
+    use super::{
+        DRAG_ICON_MAX, EDGE_MARGIN, PIN_PADDING, PIN_SIDE, cover_thumbnail, first_free_slot,
+        fit_within, pin_step, slot_of,
+    };
     use relm4::gtk::gdk_pixbuf::{Colorspace, Pixbuf};
 
     /// The pointer carries a token, not the capture: a 6K shot has to
@@ -475,7 +555,41 @@ mod tests {
     /// the first — seeing both is the point of stacking them.
     #[test]
     fn stacked_pins_do_not_overlap() {
-        let step = PIN_SIDE + PIN_PADDING * 2 + PIN_GAP;
-        assert!(step > PIN_SIDE + PIN_PADDING * 2);
+        assert!(pin_step() > PIN_SIDE + PIN_PADDING * 2);
+    }
+
+    /// A pin sitting in the column is recognised as being in its slot,
+    /// so the next one goes above it rather than on it.
+    #[test]
+    fn a_pin_in_the_column_holds_its_slot() {
+        let screen = (3072, 1728);
+        let side = PIN_SIDE + PIN_PADDING * 2;
+        let x = screen.0 - EDGE_MARGIN - side;
+        let base = screen.1 - EDGE_MARGIN - side;
+        assert_eq!(slot_of((x, base, side, side), screen), Some(0));
+        assert_eq!(slot_of((x, base - pin_step(), side, side), screen), Some(1));
+    }
+
+    /// A pin dragged out of the column gives its slot back: stacking
+    /// above where it used to be would leave a hole at the bottom and
+    /// walk new pins off the top of the screen.
+    #[test]
+    fn a_moved_pin_frees_its_slot() {
+        let screen = (3072, 1728);
+        let side = PIN_SIDE + PIN_PADDING * 2;
+        let x = screen.0 - EDGE_MARGIN - side;
+        let base = screen.1 - EDGE_MARGIN - side;
+        // Dragged left, and dragged up between two slots.
+        assert_eq!(slot_of((x - 300, base, side, side), screen), None);
+        assert_eq!(slot_of((x, base - pin_step() / 2, side, side), screen), None);
+    }
+
+    /// The next pin takes the lowest gap, not the top of the pile.
+    #[test]
+    fn the_lowest_free_slot_wins() {
+        assert_eq!(first_free_slot(&[]), 0);
+        assert_eq!(first_free_slot(&[0, 1]), 2);
+        assert_eq!(first_free_slot(&[0, 2]), 1);
+        assert_eq!(first_free_slot(&[1, 2]), 0);
     }
 }

--- a/src/pin.rs
+++ b/src/pin.rs
@@ -143,31 +143,27 @@ pub fn open(image: &Pixbuf, actions: PinActions) -> Pin {
 
     // Float it, show it on every workspace, and put it in its slot —
     // once it has a surface for the compositor to match on.
-    if on_hyprland() {
-        let slot = next_slot();
+    let desktop = Desktop::detect();
+    if desktop.places_windows() {
+        let slot = next_slot(desktop);
         window.connect_map(move |_| {
             // Not immediately: `map` is this side's word for "shown",
             // and the compositor has not necessarily registered the
-            // window under its title yet — dispatches sent then report
-            // success and do nothing, which is how a pin ended up
-            // centred and unpinned. Retry until it is there.
+            // window under its title yet — a request naming a window
+            // that isn't there reports success and does nothing, which
+            // is how a pin ended up centred and unpinned. Retry until
+            // it is there.
             let attempts = Cell::new(0);
             gtk::glib::timeout_add_local(SETTLE_INTERVAL, move || {
                 attempts.set(attempts.get() + 1);
-                if !pin_window_exists() {
+                if !desktop.sees_pin() {
                     return if attempts.get() < SETTLE_ATTEMPTS {
                         gtk::glib::ControlFlow::Continue
                     } else {
                         gtk::glib::ControlFlow::Break
                     };
                 }
-                // Floating first: a tiled window has no position of
-                // its own to set. Then pinned, so it stays put as you
-                // move between workspaces, which is most of what a pin
-                // is for.
-                hypr_dispatch(&format!("hl.dsp.window.float({{ {} }})", pin_selector()));
-                hypr_dispatch(&format!("hl.dsp.window.pin({{ {} }})", pin_selector()));
-                place_in_slot(slot);
+                desktop.arrange(slot);
                 gtk::glib::ControlFlow::Break
             });
         });
@@ -190,7 +186,7 @@ pub fn open(image: &Pixbuf, actions: PinActions) -> Pin {
     // the pin brings its own edge rather than reading as a picture
     // lying loose on the desktop.
     let overlay = gtk::Overlay::new();
-    if on_hyprland() {
+    if desktop.places_windows() {
         overlay.set_child(Some(&picture));
     } else {
         let frame = gtk::Box::new(gtk::Orientation::Horizontal, 0);
@@ -298,13 +294,177 @@ fn pin_title() -> String {
     format!("{PIN_TITLE} {}", std::process::id())
 }
 
-/// Whether the compositor is Hyprland, and so whether the pin can ask
-/// to be floated, pinned and placed.
+/// The compositors this pin knows how to ask for placement.
 ///
-/// Everything gated on this is a nicety: without it the pin still
-/// opens, still drags, and still does everything its toolbar offers.
-fn on_hyprland() -> bool {
-    std::env::var_os("HYPRLAND_INSTANCE_SIGNATURE").is_some()
+/// Wayland has no protocol for a window to position itself — that is
+/// deliberate, and every corner-placed window on Wayland goes through
+/// compositor-specific IPC. So this is a short list rather than a
+/// capability check, and everything gated on it is a nicety: an
+/// unrecognised compositor still gets a pin that opens, drags, edits,
+/// copies and drags out. It just lands where the compositor decides.
+#[derive(Clone, Copy, PartialEq)]
+enum Desktop {
+    Hyprland,
+    Sway,
+    Unknown,
+}
+
+impl Desktop {
+    fn detect() -> Self {
+        if std::env::var_os("HYPRLAND_INSTANCE_SIGNATURE").is_some() {
+            Desktop::Hyprland
+        } else if std::env::var_os("SWAYSOCK").is_some() {
+            Desktop::Sway
+        } else {
+            Desktop::Unknown
+        }
+    }
+
+    fn places_windows(self) -> bool {
+        self != Desktop::Unknown
+    }
+
+    /// Float this pin, show it on every workspace, and put it in
+    /// `slot`.
+    ///
+    /// Floating first in both: a tiled window has no position of its
+    /// own to set.
+    fn arrange(self, slot: i32) {
+        let Some((screen_w, screen_h)) = self.screen_size() else {
+            return;
+        };
+        let (frame_w, frame_h) = pin_size();
+        let x = screen_w - EDGE_MARGIN - frame_w;
+        let y = screen_h - EDGE_MARGIN - frame_h - slot * pin_step();
+        match self {
+            Desktop::Hyprland => {
+                let selector = format!("window = \"title:^({})$\"", pin_title());
+                hypr_dispatch(&format!("hl.dsp.window.float({{ {selector} }})"));
+                hypr_dispatch(&format!("hl.dsp.window.pin({{ {selector} }})"));
+                hypr_dispatch(&format!(
+                    "hl.dsp.window.move({{ x = {x}, y = {y}, relative = false, {selector} }})"
+                ));
+            }
+            Desktop::Sway => {
+                sway_command(&format!(
+                    "[title=\"^{}$\"] floating enable, sticky enable, \
+                     move absolute position {x} {y}",
+                    pin_title()
+                ));
+            }
+            Desktop::Unknown => {}
+        }
+    }
+
+    /// The focused output's size in logical pixels.
+    fn screen_size(self) -> Option<(i32, i32)> {
+        match self {
+            Desktop::Hyprland => {
+                let monitor = crate::display::hyprland_focused_monitor()?;
+                // Hyprland reports device pixels; windows are placed
+                // in logical ones.
+                let scale = (monitor.scale as f64).max(0.0001);
+                Some((
+                    (monitor.width as f64 / scale).round() as i32,
+                    (monitor.height as f64 / scale).round() as i32,
+                ))
+            }
+            Desktop::Sway => {
+                let outputs: serde_json::Value =
+                    serde_json::from_str(&sway_query("get_outputs")?).ok()?;
+                let focused = outputs
+                    .as_array()?
+                    .iter()
+                    .find(|o| o.get("focused").and_then(|f| f.as_bool()) == Some(true))?;
+                // Sway's rect is already logical.
+                let rect = focused.get("rect")?;
+                Some((
+                    rect.get("width")?.as_i64()? as i32,
+                    rect.get("height")?.as_i64()? as i32,
+                ))
+            }
+            Desktop::Unknown => None,
+        }
+    }
+
+    /// Where every pin currently sits, in logical pixels.
+    fn pin_rects(self) -> Vec<(i32, i32, i32, i32)> {
+        match self {
+            Desktop::Hyprland => hyprland_pin_rects(),
+            Desktop::Sway => sway_pin_rects(),
+            Desktop::Unknown => Vec::new(),
+        }
+    }
+
+    /// Whether this pin's window has reached the compositor yet.
+    fn sees_pin(self) -> bool {
+        let listing = match self {
+            Desktop::Hyprland => {
+                let output = std::process::Command::new("hyprctl")
+                    .args(["-j", "clients"])
+                    .output()
+                    .ok();
+                output.map(|o| String::from_utf8_lossy(&o.stdout).into_owned())
+            }
+            Desktop::Sway => sway_query("get_tree"),
+            Desktop::Unknown => None,
+        };
+        listing.is_some_and(|text| text.contains(&pin_title()))
+    }
+}
+
+/// Run one sway command, best-effort.
+fn sway_command(command: &str) {
+    let _ = std::process::Command::new("swaymsg").arg(command).output();
+}
+
+/// Ask sway for one of its JSON trees.
+fn sway_query(kind: &str) -> Option<String> {
+    let output = std::process::Command::new("swaymsg")
+        .args(["-t", kind, "-r"])
+        .output()
+        .ok()?;
+    output
+        .status
+        .success()
+        .then(|| String::from_utf8_lossy(&output.stdout).into_owned())
+}
+
+/// Every pin in sway's tree, with its geometry.
+///
+/// The tree is nested, so this walks it: a floating pin hangs off a
+/// workspace's floating list rather than sitting beside the tiled
+/// windows.
+fn sway_pin_rects() -> Vec<(i32, i32, i32, i32)> {
+    let Some(text) = sway_query("get_tree") else {
+        return Vec::new();
+    };
+    let Ok(tree) = serde_json::from_str::<serde_json::Value>(&text) else {
+        return Vec::new();
+    };
+    let mut found = Vec::new();
+    let mut pending = vec![tree];
+    while let Some(node) = pending.pop() {
+        if node
+            .get("name")
+            .and_then(|n| n.as_str())
+            .is_some_and(|name| name.starts_with(PIN_TITLE))
+            && let Some(rect) = node.get("rect")
+        {
+            let field = |key: &str| rect.get(key)?.as_i64().map(|v| v as i32);
+            if let (Some(x), Some(y), Some(w), Some(h)) =
+                (field("x"), field("y"), field("width"), field("height"))
+            {
+                found.push((x, y, w, h));
+            }
+        }
+        for key in ["nodes", "floating_nodes"] {
+            if let Some(children) = node.get(key).and_then(|c| c.as_array()) {
+                pending.extend(children.iter().cloned());
+            }
+        }
+    }
+    found
 }
 
 /// Run one Hyprland dispatcher, best-effort.
@@ -324,41 +484,6 @@ fn hypr_dispatch(expression: &str) {
         .arg("dispatch")
         .arg(expression)
         .output();
-}
-
-/// Whether the compositor has this pin's window yet.
-fn pin_window_exists() -> bool {
-    let Ok(output) = std::process::Command::new("hyprctl")
-        .args(["-j", "clients"])
-        .output()
-    else {
-        return false;
-    };
-    String::from_utf8_lossy(&output.stdout).contains(&pin_title())
-}
-
-/// How a dispatcher names this pin, and only this pin.
-fn pin_selector() -> String {
-    format!("window = \"title:^({})$\"", pin_title())
-}
-
-/// Put the pin in `slot`, counting up from the bottom-right corner.
-fn place_in_slot(slot: i32) {
-    let Some(monitor) = crate::display::hyprland_focused_monitor() else {
-        return;
-    };
-    let scale = (monitor.scale as f64).max(0.0001);
-    let (screen_w, screen_h) = (
-        (monitor.width as f64 / scale).round() as i32,
-        (monitor.height as f64 / scale).round() as i32,
-    );
-    let (frame_w, frame_h) = pin_size();
-    let x = screen_w - EDGE_MARGIN - frame_w;
-    let y = screen_h - EDGE_MARGIN - frame_h - slot * pin_step();
-    hypr_dispatch(&format!(
-        "hl.dsp.window.move({{ x = {x}, y = {y}, relative = false, {} }})",
-        pin_selector()
-    ));
 }
 
 /// How far apart stacked pins sit, centre to centre.
@@ -402,31 +527,33 @@ fn first_free_slot(occupied: &[i32]) -> i32 {
 /// tell a pin that has been dragged away from one that hasn't. A
 /// compositor that can't be asked answers zero, and the new pin lands
 /// in the corner like the first one.
-fn next_slot() -> i32 {
+fn next_slot(desktop: Desktop) -> i32 {
+    let Some(screen) = desktop.screen_size() else {
+        return 0;
+    };
+    let occupied: Vec<i32> = desktop
+        .pin_rects()
+        .into_iter()
+        .filter_map(|rect| slot_of(rect, screen))
+        .collect();
+    first_free_slot(&occupied)
+}
+
+/// Every pin Hyprland knows about, with its geometry.
+fn hyprland_pin_rects() -> Vec<(i32, i32, i32, i32)> {
     let Ok(output) = std::process::Command::new("hyprctl")
         .args(["-j", "clients"])
         .output()
     else {
-        return 0;
+        return Vec::new();
     };
     let Ok(text) = String::from_utf8(output.stdout) else {
-        return 0;
+        return Vec::new();
     };
     let Ok(clients) = serde_json::from_str::<serde_json::Value>(&text) else {
-        return 0;
+        return Vec::new();
     };
-    let Some(monitor) = crate::display::hyprland_focused_monitor() else {
-        return 0;
-    };
-    // The monitor reports device pixels; windows are placed in logical
-    // ones.
-    let scale = (monitor.scale as f64).max(0.0001);
-    let screen = (
-        (monitor.width as f64 / scale).round() as i32,
-        (monitor.height as f64 / scale).round() as i32,
-    );
-
-    let occupied: Vec<i32> = clients
+    clients
         .as_array()
         .into_iter()
         .flatten()
@@ -445,9 +572,7 @@ fn next_slot() -> i32 {
             let (w, h) = pair("size")?;
             Some((x, y, w, h))
         })
-        .filter_map(|rect| slot_of(rect, screen))
-        .collect();
-    first_free_slot(&occupied)
+        .collect()
 }
 
 /// A square thumbnail of `image` that fills `side` and centre-crops,
@@ -779,7 +904,10 @@ mod tests {
         let base = screen.1 - EDGE_MARGIN - frame_h;
         // Dragged left, and dragged up between two slots.
         assert_eq!(slot_of((x - 300, base, side, side), screen), None);
-        assert_eq!(slot_of((x, base - pin_step() / 2, side, side), screen), None);
+        assert_eq!(
+            slot_of((x, base - pin_step() / 2, side, side), screen),
+            None
+        );
     }
 
     /// The next pin takes the lowest gap, not the top of the pile.

--- a/src/pin.rs
+++ b/src/pin.rs
@@ -49,10 +49,13 @@ const MOVE_TOOLTIP: &str = "Move this pin";
 /// same reason.
 const PICTURE_TOOLTIP: &str = "Click to open in the editor · Drag into another app to paste it";
 
-/// How often a dragged pin asks where the pointer is. 16ms is a frame
-/// at 60Hz: often enough to look attached, rare enough that the socket
-/// round-trip costs nothing.
-const FOLLOW_INTERVAL: Duration = Duration::from_millis(16);
+/// How often a dragged pin asks where the pointer is.
+///
+/// Twice a frame at 60Hz. The cost is a socket round-trip, which is
+/// sub-millisecond; the win is that a step is never more than half a
+/// frame stale before it is drawn, which is the difference between a
+/// pin that feels attached to the pointer and one that trails it.
+const FOLLOW_INTERVAL: Duration = Duration::from_millis(8);
 
 /// Gap between stacked pins.
 const PIN_GAP: i32 = 12;
@@ -183,7 +186,7 @@ pub fn open(image: &Pixbuf, actions: PinActions) -> Pin {
 
     // The picture is the shot: clicking it opens the shot, dragging it
     // carries the shot somewhere.
-    picture.set_tooltip_text(Some(PICTURE_TOOLTIP));
+    picture.install_tooltip(PICTURE_TOOLTIP);
     picture.set_cursor_from_name(Some("pointer"));
     install_drag_out(&picture, image, saved_path_for_drag);
     {
@@ -438,17 +441,9 @@ fn install_drag_out(handle: &gtk::Picture, image: &Pixbuf, saved_path: Option<St
             source.set_icon(Some(&icon), icon_w / 2, icon_h / 2);
         });
     }
-    {
-        // Same tooltip problem as the move handle: a drag-out leaves
-        // the pointer over a picture that is now carrying something,
-        // and the tooltip follows it around.
-        let handle_begin = handle.clone();
-        source.connect_drag_begin(move |_, _| handle_begin.set_has_tooltip(false));
-        let handle_end = handle.clone();
-        source.connect_drag_end(move |_, _, _| {
-            handle_end.set_tooltip_text(Some(PICTURE_TOOLTIP));
-        });
-    }
+    // Same problem on a drag-out: the pointer is over a picture that
+    // is now carrying something, and the tooltip follows it.
+    source.connect_drag_begin(|_, _| crate::ui::toolbars::dismiss_active_tooltip());
     handle.add_controller(source);
 }
 
@@ -492,7 +487,6 @@ fn install_move(window: &gtk::Window, target: &gtk::Button, bottom_margin: i32) 
     let press = gtk::GestureClick::new();
     {
         let window = window.clone();
-        let target_press = target.clone();
         let right = right.clone();
         let bottom = bottom.clone();
         let dragging = dragging.clone();
@@ -506,14 +500,9 @@ fn install_move(window: &gtk::Window, target: &gtk::Button, bottom_margin: i32) 
             if dragging.replace(true) {
                 return;
             }
-            // The tooltip would otherwise reappear on every step: the
-            // window slides out from under the pointer, which GTK
-            // reads as a fresh hover.
-            target_press.set_has_tooltip(false);
 
             let start = (right.get(), bottom.get());
             let window = window.clone();
-            let target_tick = target_press.clone();
             let right = right.clone();
             let bottom = bottom.clone();
             let dragging = dragging.clone();
@@ -523,9 +512,12 @@ fn install_move(window: &gtk::Window, target: &gtk::Button, bottom_margin: i32) 
             // was falling behind.
             gtk::glib::timeout_add_local(FOLLOW_INTERVAL, move || {
                 if !dragging.get() {
-                    target_tick.set_tooltip_text(Some(MOVE_TOOLTIP));
                     return gtk::glib::ControlFlow::Break;
                 }
+                // Every tick, because the pointer never leaves the
+                // handle during a drag: nothing else would take the
+                // tooltip down, and it would tag along beside the pin.
+                crate::ui::toolbars::dismiss_active_tooltip();
                 let Some((x, y)) = crate::hypr::cursor_position() else {
                     return gtk::glib::ControlFlow::Continue;
                 };

--- a/src/pin.rs
+++ b/src/pin.rs
@@ -465,11 +465,15 @@ fn cover_thumbnail(image: &Pixbuf, frame: (i32, i32)) -> Pixbuf {
     let Some(scaled) = image.scale_simple(scaled_w, scaled_h, InterpType::Bilinear) else {
         return image.clone();
     };
-    // Take the middle: a capture's edges are where its chrome is, and
-    // its middle is what it was taken of. A capture shaped like the
-    // screen crops nothing, which is the point of the frame's shape.
+    // Centred horizontally, but anchored to the top rather than the
+    // middle: a capture's top is its title bar, its tab strip, its
+    // heading — what tells you which shot this is. A tall page cropped
+    // to its middle is a slab of body text that could be any of them.
+    //
+    // A capture shaped like the screen crops nothing either way, which
+    // is the point of the frame's shape.
     let x = ((scaled_w - frame_w) / 2).max(0);
-    let y = ((scaled_h - frame_h) / 2).max(0);
+    let y = 0;
     scaled.new_subpixbuf(x, y, frame_w.min(scaled_w), frame_h.min(scaled_h))
 }
 
@@ -695,13 +699,36 @@ mod tests {
         assert_eq!((thumb.width(), thumb.height()), frame);
     }
 
-    /// A tall stitch is cropped to its middle for the same reason.
+    /// A tall stitch is cropped to its top for the same reason.
     #[test]
     fn a_tall_capture_fills_the_frame() {
         let frame = (224, 126);
         let tall = Pixbuf::new(Colorspace::Rgb, true, 8, 600, 9000).unwrap();
         let thumb = cover_thumbnail(&tall, frame);
         assert_eq!((thumb.width(), thumb.height()), frame);
+    }
+
+    /// A tall capture keeps its top, where the heading and the tabs
+    /// are — the part that says which shot this is. Its middle is
+    /// body text that could belong to any of them.
+    #[test]
+    fn a_tall_capture_keeps_its_top() {
+        let frame = (224, 126);
+        // A page with a red band across its first rows and black
+        // below. Cover-scaling a 448-wide capture into a 224-wide
+        // frame halves it, so the frame shows the capture's top 252
+        // rows: the band has to be shallower than that to leave any
+        // black in the picture at all.
+        let tall = Pixbuf::new(Colorspace::Rgb, true, 8, 448, 4000).unwrap();
+        tall.fill(0x000000ff);
+        tall.new_subpixbuf(0, 0, 448, 100).fill(0xff0000ff);
+        let thumb = cover_thumbnail(&tall, frame);
+        let pixels = unsafe { thumb.pixels() };
+        let stride = thumb.rowstride() as usize;
+        let top_row_is_red = pixels[..3] == [0xff, 0x00, 0x00];
+        let bottom_row = &pixels[stride * (frame.1 as usize - 1)..];
+        assert!(top_row_is_red, "expected the capture's top to survive");
+        assert_eq!(&bottom_row[..3], &[0x00, 0x00, 0x00]);
     }
 
     /// A capture shaped like the screen loses nothing: the frame is

--- a/src/pin.rs
+++ b/src/pin.rs
@@ -49,6 +49,13 @@ const MOVE_TOOLTIP: &str = "Move this pin";
 /// same reason.
 const PICTURE_TOOLTIP: &str = "Click to open in the editor · Drag into another app to paste it";
 
+/// How often, and how many times, to look for the window before
+/// giving up on placing it. Half a second in total: long enough for a
+/// compositor under load, short enough that a failure doesn't leave a
+/// pin drifting in from the middle of the screen much later.
+const SETTLE_INTERVAL: Duration = Duration::from_millis(50);
+const SETTLE_ATTEMPTS: u32 = 10;
+
 /// Gap between stacked pins.
 const PIN_GAP: i32 = 12;
 
@@ -104,7 +111,7 @@ pub fn open(image: &Pixbuf, actions: PinActions) -> Pin {
     let window = gtk::Window::builder()
         .resizable(false)
         .decorated(false)
-        .title(PIN_TITLE)
+        .title(pin_title())
         .build();
     window.add_css_class("pin-window");
 
@@ -115,14 +122,30 @@ pub fn open(image: &Pixbuf, actions: PinActions) -> Pin {
     {
         let slot = next_slot();
         window.connect_map(move |_| {
-            for dispatch in [
-                format!("setfloating,title:^({PIN_TITLE})$"),
-                format!("pin,title:^({PIN_TITLE})$"),
-                format!("alterzorder top,title:^({PIN_TITLE})$"),
-            ] {
-                hypr_dispatch(&dispatch);
-            }
-            place_in_slot(slot);
+            // Not immediately: `map` is this side's word for "shown",
+            // and the compositor has not necessarily registered the
+            // window under its title yet — dispatches sent then report
+            // success and do nothing, which is how a pin ended up
+            // centred and unpinned. Retry until it is there.
+            let attempts = Cell::new(0);
+            gtk::glib::timeout_add_local(SETTLE_INTERVAL, move || {
+                attempts.set(attempts.get() + 1);
+                if !pin_window_exists() {
+                    return if attempts.get() < SETTLE_ATTEMPTS {
+                        gtk::glib::ControlFlow::Continue
+                    } else {
+                        gtk::glib::ControlFlow::Break
+                    };
+                }
+                // Floating first: a tiled window has no position of
+                // its own to set. Then pinned, so it stays put as you
+                // move between workspaces, which is most of what a pin
+                // is for.
+                hypr_dispatch(&format!("hl.dsp.window.float({{ {} }})", pin_selector()));
+                hypr_dispatch(&format!("hl.dsp.window.pin({{ {} }})", pin_selector()));
+                place_in_slot(slot);
+                gtk::glib::ControlFlow::Break
+            });
         });
     }
 
@@ -135,6 +158,9 @@ pub fn open(image: &Pixbuf, actions: PinActions) -> Pin {
     picture.set_can_shrink(true);
     picture.set_size_request(PIN_SIDE, PIN_SIDE);
 
+    // No border of our own: the compositor draws one around a
+    // floating window, and two frames around one picture is one frame
+    // too many.
     let frame = gtk::Box::new(gtk::Orientation::Horizontal, 0);
     frame.add_css_class("pin-frame");
     frame.append(&picture);
@@ -224,20 +250,56 @@ fn build_toast() -> (gtk::Label, Toast) {
     (label, Rc::new(show))
 }
 
-/// Window title, which is how the compositor is told which window to
-/// float, pin and place — and how pins recognise each other.
+/// Title prefix, shared by every pin so they can recognise each other,
+/// and followed by something unique so a dispatcher can name exactly
+/// one of them.
+///
+/// Without the unique half, `title:^(Tensaku Pin)$` matches every pin
+/// on screen and the compositor acts on whichever it finds first — so
+/// opening a second pin moved the first one into the second's slot and
+/// left the second where it spawned.
 const PIN_TITLE: &str = "Tensaku Pin";
+
+/// This pin's own title.
+fn pin_title() -> String {
+    // The process id is enough: a capture is a process, and a process
+    // has one pin.
+    format!("{PIN_TITLE} {}", std::process::id())
+}
 
 /// Run one Hyprland dispatcher, best-effort.
 ///
 /// Dispatchers rather than window rules: rules have to exist before a
-/// window maps and live in the user's config, and a pin should not
-/// need either.
-fn hypr_dispatch(args: &str) {
+/// window maps and live in the user's config, and a pin should need
+/// neither.
+///
+/// Written in the Lua object API, because a Lua-configured Hyprland
+/// evaluates the dispatch argument as Lua — classic
+/// `movewindowpixel exact X Y,title:...` parses as an expression and
+/// fails, which is how a pin ended up in the middle of the screen
+/// unpinned while every call reported success. The whole expression is
+/// one argument: the window title has a space in it.
+fn hypr_dispatch(expression: &str) {
     let _ = std::process::Command::new("hyprctl")
         .arg("dispatch")
-        .args(args.split(' '))
+        .arg(expression)
         .output();
+}
+
+/// Whether the compositor has this pin's window yet.
+fn pin_window_exists() -> bool {
+    let Ok(output) = std::process::Command::new("hyprctl")
+        .args(["-j", "clients"])
+        .output()
+    else {
+        return false;
+    };
+    String::from_utf8_lossy(&output.stdout).contains(&pin_title())
+}
+
+/// How a dispatcher names this pin, and only this pin.
+fn pin_selector() -> String {
+    format!("window = \"title:^({})$\"", pin_title())
 }
 
 /// Put the pin in `slot`, counting up from the bottom-right corner.
@@ -253,7 +315,10 @@ fn place_in_slot(slot: i32) {
     let side = PIN_SIDE + PIN_PADDING * 2;
     let x = screen_w - EDGE_MARGIN - side;
     let y = screen_h - EDGE_MARGIN - side - slot * pin_step();
-    hypr_dispatch(&format!("movewindowpixel exact {x} {y},title:^({PIN_TITLE})$"));
+    hypr_dispatch(&format!(
+        "hl.dsp.window.move({{ x = {x}, y = {y}, relative = false, {} }})",
+        pin_selector()
+    ));
 }
 
 /// How far apart stacked pins sit, centre to centre.
@@ -325,7 +390,12 @@ fn next_slot() -> i32 {
         .as_array()
         .into_iter()
         .flatten()
-        .filter(|client| client.get("title").and_then(|t| t.as_str()) == Some(PIN_TITLE))
+        .filter(|client| {
+            client
+                .get("title")
+                .and_then(|t| t.as_str())
+                .is_some_and(|title| title.starts_with(PIN_TITLE))
+        })
         .filter_map(|client| {
             let pair = |key: &str| {
                 let v = client.get(key)?.as_array()?;

--- a/src/pin.rs
+++ b/src/pin.rs
@@ -21,16 +21,20 @@
 
 use crate::ui::toolbars::RobustTooltipExt;
 use gtk4_layer_shell::{Edge, KeyboardMode, Layer, LayerShell};
+use relm4::gtk::gdk_pixbuf::InterpType;
 use relm4::gtk::{self, gdk_pixbuf::Pixbuf, prelude::*};
 use std::cell::Cell;
 use std::rc::Rc;
 use std::time::Duration;
 
-/// Width of a pinned capture, in CSS pixels. Height follows the
-/// image's aspect. Big enough to tell one shot from another, small
-/// enough to leave the desktop usable — a pin is a reminder of what
-/// you took, not a window to work in.
-const PIN_WIDTH: i32 = 186;
+/// Side of a pinned capture, in CSS pixels.
+///
+/// Square whatever the shot's shape: pins stack, and a column of
+/// mismatched heights is one that has to be laid out rather than
+/// counted. The image fills the square and centre-crops, so a wide
+/// capture shows its middle instead of becoming a letterboxed sliver
+/// too small to recognise.
+const PIN_SIDE: i32 = 168;
 
 /// Frame around the preview: the pin needs an edge of its own or it
 /// reads as a picture lying loose on the desktop rather than a thing
@@ -106,8 +110,9 @@ pub fn open(image: &Pixbuf, actions: PinActions) -> Pin {
     // Stack above whatever is already pinned instead of landing on
     // top of it. Each capture is its own process, so the count comes
     // from the compositor rather than from a shared list.
-    let (width, height) = scaled_size(image.width(), image.height());
-    let bottom = EDGE_MARGIN + stacked_pins() * (height + PIN_PADDING * 2 + PIN_GAP);
+    // Every pin is the same square, so each new one sits exactly one
+    // step above the last rather than needing anyone's height.
+    let bottom = EDGE_MARGIN + stacked_pins() * (PIN_SIDE + PIN_PADDING * 2 + PIN_GAP);
     window.set_margin(Edge::Right, EDGE_MARGIN);
     window.set_margin(Edge::Bottom, bottom);
     // OnDemand rather than Exclusive: the pin should never swallow the
@@ -115,19 +120,16 @@ pub fn open(image: &Pixbuf, actions: PinActions) -> Pin {
     // has to reach it once it is clicked.
     window.set_keyboard_mode(KeyboardMode::OnDemand);
 
-    window.set_default_size(width + PIN_PADDING * 2, height + PIN_PADDING * 2);
+    window.set_default_size(PIN_SIDE + PIN_PADDING * 2, PIN_SIDE + PIN_PADDING * 2);
 
-    // Scale the pixels down rather than asking the widget to shrink
+    // Scale the pixels here rather than asking the widget to shrink
     // them. A `Picture`'s natural size is its image's, so a 6K capture
     // asked for a 6K surface and the compositor clamped it — which is
     // why a pin showed a corner at full size instead of the shot.
-    let preview = image
-        .scale_simple(width, height, gtk::gdk_pixbuf::InterpType::Bilinear)
-        .unwrap_or_else(|| image.clone());
+    let preview = cover_thumbnail(image, PIN_SIDE);
     let picture = gtk::Picture::for_pixbuf(&preview);
     picture.set_can_shrink(true);
-    picture.set_keep_aspect_ratio(true);
-    picture.set_size_request(width, height);
+    picture.set_size_request(PIN_SIDE, PIN_SIDE);
 
     let frame = gtk::Box::new(gtk::Orientation::Horizontal, 0);
     frame.add_css_class("pin-frame");
@@ -136,7 +138,16 @@ pub fn open(image: &Pixbuf, actions: PinActions) -> Pin {
     let overlay = gtk::Overlay::new();
     overlay.set_child(Some(&frame));
 
-    let controls = build_controls(&window, image, actions);
+    // The picture and the Edit button do the same thing, so they share
+    // one callback rather than each getting a copy of the intent.
+    let saved_path_for_drag = actions.saved_path.clone();
+    let edit_for_picture = std::rc::Rc::new(actions.on_edit);
+    let edit_for_controls = edit_for_picture.clone();
+    let actions = PinActions {
+        on_edit: Box::new(move || edit_for_controls()),
+        ..actions
+    };
+    let controls = build_controls(&window, actions);
     overlay.add_overlay(&controls);
 
     let (toast_label, toast) = build_toast();
@@ -156,7 +167,20 @@ pub fn open(image: &Pixbuf, actions: PinActions) -> Pin {
     }
     overlay.add_controller(motion);
 
-    install_drag(&window, &overlay);
+    // The picture is the shot: clicking it opens the shot, dragging it
+    // carries the shot somewhere.
+    install_drag_out(&picture, image, saved_path_for_drag);
+    {
+        let edit = edit_for_picture;
+        let click = gtk::GestureClick::new();
+        click.connect_released(move |gesture, count, _, _| {
+            if count == 1 {
+                gesture.set_state(gtk::EventSequenceState::Claimed);
+                edit();
+            }
+        });
+        picture.add_controller(click);
+    }
 
     window.set_child(Some(&overlay));
     window.present();
@@ -216,21 +240,29 @@ fn stacked_pins() -> i32 {
     text.matches(PIN_NAMESPACE).count() as i32
 }
 
-/// Fit `PIN_WIDTH` while keeping the capture's aspect, and never let a
-/// very tall shot (a scroll capture) grow past a screenful.
-fn scaled_size(image_width: i32, image_height: i32) -> (i32, i32) {
-    let width = PIN_WIDTH.min(image_width.max(1));
-    let height = (width as f64 * image_height.max(1) as f64 / image_width.max(1) as f64)
-        .round()
-        .max(1.0) as i32;
-    // A long stitch pinned at its full aspect would run off the screen;
-    // cap it and let the picture letterbox instead.
-    let capped = height.min(PIN_WIDTH * 3);
-    (width, capped)
+/// A square thumbnail of `image` that fills `side` and centre-crops,
+/// the way CSS `object-fit: cover` does.
+///
+/// Fitting inside the square would letterbox a wide capture down to a
+/// sliver, and a pin you can't recognise is one you have to open to
+/// identify.
+fn cover_thumbnail(image: &Pixbuf, side: i32) -> Pixbuf {
+    let (w, h) = (image.width().max(1), image.height().max(1));
+    let scale = (side as f64 / w as f64).max(side as f64 / h as f64);
+    let scaled_w = ((w as f64 * scale).round() as i32).max(side);
+    let scaled_h = ((h as f64 * scale).round() as i32).max(side);
+    let Some(scaled) = image.scale_simple(scaled_w, scaled_h, InterpType::Bilinear) else {
+        return image.clone();
+    };
+    // Take the middle: a capture's edges are where its chrome is, and
+    // its middle is what it was taken of.
+    let x = ((scaled_w - side) / 2).max(0);
+    let y = ((scaled_h - side) / 2).max(0);
+    scaled.new_subpixbuf(x, y, side.min(scaled_w), side.min(scaled_h))
 }
 
 /// The hover toolbar: edit, copy, copy path, close.
-fn build_controls(window: &gtk::Window, image: &Pixbuf, actions: PinActions) -> gtk::Box {
+fn build_controls(window: &gtk::Window, actions: PinActions) -> gtk::Box {
     let controls = gtk::Box::new(gtk::Orientation::Horizontal, 4);
     controls.add_css_class("pin-controls");
     controls.set_halign(gtk::Align::End);
@@ -255,20 +287,18 @@ fn build_controls(window: &gtk::Window, image: &Pixbuf, actions: PinActions) -> 
         on_copy,
         on_copy_path,
         path_known,
-        saved_path,
+        saved_path: _,
     } = actions;
 
-    // Drag-out handle. It needs a control of its own because the image
-    // itself already drags — that moves the pin — and one gesture
-    // can't mean both "take this file somewhere" and "put this window
-    // somewhere".
-    let drag_out = button(
-        "re-order-dots-horizontal-regular",
-        "Drag out to another app",
-    );
-    drag_out.add_css_class("pin-drag-handle");
-    install_drag_out(&drag_out, image, saved_path);
-    controls.append(&drag_out);
+    // Moving the pin lives here rather than on the picture. A layer
+    // surface moves by its margins, so a window dragged by its whole
+    // face trails the pointer instead of following it — and the
+    // picture has better things to answer for: a click opens the shot,
+    // a drag carries it into another app.
+    let move_handle = button("re-order-dots-horizontal-regular", "Move this pin");
+    move_handle.add_css_class("pin-drag-handle");
+    install_move(window, &move_handle);
+    controls.append(&move_handle);
 
     let edit = button("pen-regular", "Edit again");
     edit.connect_clicked(move |_| on_edit());
@@ -303,7 +333,7 @@ fn build_controls(window: &gtk::Window, image: &Pixbuf, actions: PinActions) -> 
 /// or an upload field wants, and the image itself, which is what a
 /// chat window or an editor takes. An unsaved pin has no file to
 /// offer, so it drags the image alone rather than a path to nothing.
-fn install_drag_out(handle: &gtk::Button, image: &Pixbuf, saved_path: Option<String>) {
+fn install_drag_out(handle: &gtk::Picture, image: &Pixbuf, saved_path: Option<String>) {
     let texture = gtk::gdk::Texture::for_pixbuf(image);
     let source = gtk::DragSource::new();
     source.set_actions(gtk::gdk::DragAction::COPY);
@@ -356,14 +386,14 @@ fn fit_within(width: i32, height: i32, max: i32) -> (i32, i32) {
     )
 }
 
-/// Drag the pin around by its image.
+/// Drag the pin around by its handle.
 ///
 /// A layer surface is positioned by its anchor margins, not by the
 /// compositor, so a drag has to move those margins itself — and both
 /// anchors are on the far edges, so a rightward drag *shrinks* the
 /// right margin. The margins are held here rather than read back
 /// because `LayerShell` exposes no getter for them.
-fn install_drag(window: &gtk::Window, target: &gtk::Overlay) {
+fn install_move(window: &gtk::Window, target: &gtk::Button) {
     let right = Rc::new(Cell::new(EDGE_MARGIN));
     let bottom = Rc::new(Cell::new(EDGE_MARGIN));
     let start = Rc::new(Cell::new((EDGE_MARGIN, EDGE_MARGIN)));
@@ -396,7 +426,8 @@ fn install_drag(window: &gtk::Window, target: &gtk::Overlay) {
 
 #[cfg(test)]
 mod tests {
-    use super::{DRAG_ICON_MAX, PIN_GAP, PIN_PADDING, PIN_WIDTH, fit_within, scaled_size};
+    use super::{DRAG_ICON_MAX, PIN_GAP, PIN_PADDING, PIN_SIDE, cover_thumbnail, fit_within};
+    use relm4::gtk::gdk_pixbuf::{Colorspace, Pixbuf};
 
     /// The pointer carries a token, not the capture: a 6K shot has to
     /// come down to something a pointer can drag.
@@ -422,34 +453,29 @@ mod tests {
         assert_eq!(fit_within(80, 40, DRAG_ICON_MAX), (80, 40));
     }
 
+    /// The preview fills its square and crops rather than fitting
+    /// inside it: a wide capture letterboxed into a sliver is
+    /// unrecognisable, which defeats having a pin at all.
     #[test]
-    fn a_pin_keeps_the_capture_aspect() {
-        let (w, h) = scaled_size(1600, 900);
-        assert_eq!(w, PIN_WIDTH);
-        assert_eq!(h, (PIN_WIDTH as f64 * 900.0 / 1600.0).round() as i32);
+    fn a_wide_capture_fills_the_square() {
+        let wide = Pixbuf::new(Colorspace::Rgb, true, 8, 1600, 400).unwrap();
+        let thumb = cover_thumbnail(&wide, PIN_SIDE);
+        assert_eq!((thumb.width(), thumb.height()), (PIN_SIDE, PIN_SIDE));
     }
 
-    /// A shot narrower than the pin shouldn't be blown up to fill it.
+    /// A tall stitch is cropped to its middle for the same reason.
     #[test]
-    fn a_small_capture_stays_its_own_size() {
-        let (w, h) = scaled_size(120, 60);
-        assert_eq!((w, h), (120, 60));
-    }
-
-    /// A long scroll capture is capped rather than running off screen.
-    #[test]
-    fn a_long_stitch_is_capped() {
-        let (_, h) = scaled_size(1000, 40_000);
-        assert_eq!(h, PIN_WIDTH * 3);
+    fn a_tall_capture_fills_the_square() {
+        let tall = Pixbuf::new(Colorspace::Rgb, true, 8, 600, 9000).unwrap();
+        let thumb = cover_thumbnail(&tall, PIN_SIDE);
+        assert_eq!((thumb.width(), thumb.height()), (PIN_SIDE, PIN_SIDE));
     }
 
     /// Pins stack clear of each other, so a second one doesn't bury
-    /// the first — the whole point of seeing both is telling them
-    /// apart.
+    /// the first — seeing both is the point of stacking them.
     #[test]
     fn stacked_pins_do_not_overlap() {
-        let (_, height) = scaled_size(1600, 900);
-        let step = height + PIN_PADDING * 2 + PIN_GAP;
-        assert!(step > height + PIN_PADDING * 2);
+        let step = PIN_SIDE + PIN_PADDING * 2 + PIN_GAP;
+        assert!(step > PIN_SIDE + PIN_PADDING * 2);
     }
 }

--- a/src/pin.rs
+++ b/src/pin.rs
@@ -58,6 +58,20 @@ const PICTURE_TOOLTIP: &str = "Click to open in the editor · Drag into another 
 /// waiting when the next frame asks for it.
 const POLL_INTERVAL: Duration = Duration::from_millis(2);
 
+/// How far ahead of the pointer to place a dragged pin. Measured: the
+/// pin lands about 12ms behind the pointer, and that is a frame of
+/// compositor work rather than anything this side can skip.
+const LEAD: Duration = Duration::from_millis(12);
+
+/// Most a lead may add, in pixels. Past a flick this fast the guess is
+/// worth less than the overshoot it causes.
+const LEAD_CAP: i32 = 48;
+
+/// How much of each reading folds into the smoothed speed. Low enough
+/// that a jittery hand doesn't throw the lead around, high enough that
+/// a change of direction is followed within a frame or two.
+const VELOCITY_BLEND: f32 = 0.35;
+
 /// Gap between stacked pins.
 const PIN_GAP: i32 = 12;
 
@@ -505,10 +519,12 @@ fn install_move(window: &gtk::Window, target: &gtk::Button, bottom_margin: i32) 
             {
                 let cursor = Arc::clone(&cursor);
                 std::thread::spawn(move || {
+                    let mut last = std::time::Instant::now();
                     while cursor.following.load(Ordering::Relaxed) {
                         if let Some((x, y)) = crate::hypr::cursor_position() {
-                            cursor.x.store(x, Ordering::Relaxed);
-                            cursor.y.store(y, Ordering::Relaxed);
+                            let now = std::time::Instant::now();
+                            cursor.sample(x, y, now.duration_since(last).as_secs_f32());
+                            last = now;
                         }
                         std::thread::sleep(POLL_INTERVAL);
                     }
@@ -533,8 +549,7 @@ fn install_move(window: &gtk::Window, target: &gtk::Button, bottom_margin: i32) 
                 // down.
                 crate::ui::toolbars::dismiss_active_tooltip();
 
-                let x = cursor_for_tick.x.load(Ordering::Relaxed);
-                let y = cursor_for_tick.y.load(Ordering::Relaxed);
+                let (x, y) = cursor_for_tick.predicted();
                 // Anchored bottom-right, so moving right shrinks the
                 // right margin. Clamped so a pin can't be pushed off
                 // the edge it hangs from and out of reach.
@@ -572,6 +587,11 @@ fn install_move(window: &gtk::Window, target: &gtk::Button, bottom_margin: i32) 
 struct CursorFollow {
     x: AtomicI32,
     y: AtomicI32,
+    /// Pointer speed in pixels per second, smoothed. Used to place the
+    /// pin where the pointer will be when the frame lands rather than
+    /// where it was when the frame was built.
+    vx: AtomicI32,
+    vy: AtomicI32,
     following: AtomicBool,
 }
 
@@ -580,8 +600,54 @@ impl CursorFollow {
         Self {
             x: AtomicI32::new(origin.0),
             y: AtomicI32::new(origin.1),
+            vx: AtomicI32::new(0),
+            vy: AtomicI32::new(0),
             following: AtomicBool::new(true),
         }
+    }
+
+    /// Where the pointer will be `LEAD` from now, at its current
+    /// speed.
+    ///
+    /// Measured end to end, a pin lands about 12ms after the pointer
+    /// it is following: the compositor has to accept a new margin,
+    /// lay the surface out and present it, and that is a frame's work
+    /// however the margin got there. Leading by that much cancels it,
+    /// which is what turns "close behind" into "attached".
+    ///
+    /// Capped, because a lead is a guess: at a direction change the
+    /// guess is wrong, and a small wrong guess reads as softness while
+    /// a large one reads as the pin overshooting and snapping back.
+    fn predicted(&self) -> (i32, i32) {
+        let lead = LEAD.as_secs_f32();
+        let step = |v: &AtomicI32| {
+            ((v.load(Ordering::Relaxed) as f32 * lead).round() as i32).clamp(-LEAD_CAP, LEAD_CAP)
+        };
+        (
+            self.x.load(Ordering::Relaxed) + step(&self.vx),
+            self.y.load(Ordering::Relaxed) + step(&self.vy),
+        )
+    }
+
+    /// Record a reading and fold it into the smoothed speed.
+    fn sample(&self, x: i32, y: i32, dt: f32) {
+        if dt > 0.0 {
+            let blend = |old: &AtomicI32, delta: i32| {
+                let instant = delta as f32 / dt;
+                let previous = old.load(Ordering::Relaxed) as f32;
+                // A plain difference of two readings is mostly noise
+                // at this rate; the average of the recent past is what
+                // a hand is actually doing.
+                old.store(
+                    (previous * (1.0 - VELOCITY_BLEND) + instant * VELOCITY_BLEND).round() as i32,
+                    Ordering::Relaxed,
+                );
+            };
+            blend(&self.vx, x - self.x.load(Ordering::Relaxed));
+            blend(&self.vy, y - self.y.load(Ordering::Relaxed));
+        }
+        self.x.store(x, Ordering::Relaxed);
+        self.y.store(y, Ordering::Relaxed);
     }
 }
 

--- a/src/pin.rs
+++ b/src/pin.rs
@@ -27,14 +27,32 @@ use std::cell::Cell;
 use std::rc::Rc;
 use std::time::Duration;
 
-/// Side of a pinned capture, in CSS pixels.
+/// Width of a pinned capture, in CSS pixels. The height follows the
+/// display's aspect.
 ///
-/// Square whatever the shot's shape: pins stack, and a column of
-/// mismatched heights is one that has to be laid out rather than
-/// counted. The image fills the square and centre-crops, so a wide
-/// capture shows its middle instead of becoming a letterboxed sliver
-/// too small to recognise.
-const PIN_SIDE: i32 = 168;
+/// Shaped like the screen, so a full-screen capture — the most common
+/// kind — fits its pin exactly, with nothing cropped away. Everything
+/// else fills the same frame and centre-crops, which keeps pins a
+/// uniform size: they stack, and a column of mismatched heights is one
+/// that has to be laid out rather than counted.
+const PIN_WIDTH: i32 = 224;
+
+/// Fallback aspect when the display can't be asked. 16:9 is the shape
+/// of most screens and a reasonable guess for the rest.
+const FALLBACK_ASPECT: f64 = 9.0 / 16.0;
+
+/// The frame a pin's picture fills: the display's aspect at
+/// [`PIN_WIDTH`].
+fn pin_size() -> (i32, i32) {
+    let aspect = crate::display::hyprland_focused_monitor()
+        .filter(|m| m.width > 0 && m.height > 0)
+        .map(|m| m.height as f64 / m.width as f64)
+        .unwrap_or(FALLBACK_ASPECT);
+    // Clamped so an unusual display — a tall pivot, an ultrawide —
+    // still yields a pin rather than a line.
+    let height = ((PIN_WIDTH as f64 * aspect).round() as i32).clamp(PIN_WIDTH / 4, PIN_WIDTH * 2);
+    (PIN_WIDTH, height)
+}
 
 /// Frame around the preview: the pin needs an edge of its own or it
 /// reads as a picture lying loose on the desktop rather than a thing
@@ -115,7 +133,8 @@ pub fn open(image: &Pixbuf, actions: PinActions) -> Pin {
         .build();
     window.add_css_class("pin-window");
 
-    window.set_default_size(PIN_SIDE + PIN_PADDING * 2, PIN_SIDE + PIN_PADDING * 2);
+    let (frame_w, frame_h) = pin_size();
+    window.set_default_size(frame_w + PIN_PADDING * 2, frame_h + PIN_PADDING * 2);
 
     // Float it, show it on every workspace, and put it in its slot —
     // once it has a surface for the compositor to match on.
@@ -153,10 +172,10 @@ pub fn open(image: &Pixbuf, actions: PinActions) -> Pin {
     // them. A `Picture`'s natural size is its image's, so a 6K capture
     // asked for a 6K surface and the compositor clamped it — which is
     // why a pin showed a corner at full size instead of the shot.
-    let preview = cover_thumbnail(image, PIN_SIDE);
+    let preview = cover_thumbnail(image, (frame_w, frame_h));
     let picture = gtk::Picture::for_pixbuf(&preview);
     picture.set_can_shrink(true);
-    picture.set_size_request(PIN_SIDE, PIN_SIDE);
+    picture.set_size_request(frame_w, frame_h);
 
     // No border of our own: the compositor draws one around a
     // floating window, and two frames around one picture is one frame
@@ -312,9 +331,9 @@ fn place_in_slot(slot: i32) {
         (monitor.width as f64 / scale).round() as i32,
         (monitor.height as f64 / scale).round() as i32,
     );
-    let side = PIN_SIDE + PIN_PADDING * 2;
-    let x = screen_w - EDGE_MARGIN - side;
-    let y = screen_h - EDGE_MARGIN - side - slot * pin_step();
+    let (frame_w, frame_h) = pin_size();
+    let x = screen_w - EDGE_MARGIN - (frame_w + PIN_PADDING * 2);
+    let y = screen_h - EDGE_MARGIN - (frame_h + PIN_PADDING * 2) - slot * pin_step();
     hypr_dispatch(&format!(
         "hl.dsp.window.move({{ x = {x}, y = {y}, relative = false, {} }})",
         pin_selector()
@@ -323,7 +342,7 @@ fn place_in_slot(slot: i32) {
 
 /// How far apart stacked pins sit, centre to centre.
 fn pin_step() -> i32 {
-    PIN_SIDE + PIN_PADDING * 2 + PIN_GAP
+    pin_size().1 + PIN_PADDING * 2 + PIN_GAP
 }
 
 /// The slot a pin at `rect` is sitting in, or `None` if it isn't in
@@ -337,12 +356,12 @@ fn slot_of(rect: (i32, i32, i32, i32), screen: (i32, i32)) -> Option<i32> {
     /// A pin within a few pixels of a slot is in it: margins round to
     /// integers and compositors report what they rounded to.
     const TOLERANCE: i32 = 4;
-    let side = PIN_SIDE + PIN_PADDING * 2;
+    let (frame_w, frame_h) = pin_size();
     let (x, y, _, _) = rect;
-    if (x - (screen.0 - EDGE_MARGIN - side)).abs() > TOLERANCE {
+    if (x - (screen.0 - EDGE_MARGIN - (frame_w + PIN_PADDING * 2))).abs() > TOLERANCE {
         return None;
     }
-    let base = screen.1 - EDGE_MARGIN - side;
+    let base = screen.1 - EDGE_MARGIN - (frame_h + PIN_PADDING * 2);
     let step = pin_step();
     let index = ((base - y) as f64 / step as f64).round() as i32;
     let expected = base - index * step;
@@ -416,19 +435,21 @@ fn next_slot() -> i32 {
 /// Fitting inside the square would letterbox a wide capture down to a
 /// sliver, and a pin you can't recognise is one you have to open to
 /// identify.
-fn cover_thumbnail(image: &Pixbuf, side: i32) -> Pixbuf {
+fn cover_thumbnail(image: &Pixbuf, frame: (i32, i32)) -> Pixbuf {
+    let (frame_w, frame_h) = (frame.0.max(1), frame.1.max(1));
     let (w, h) = (image.width().max(1), image.height().max(1));
-    let scale = (side as f64 / w as f64).max(side as f64 / h as f64);
-    let scaled_w = ((w as f64 * scale).round() as i32).max(side);
-    let scaled_h = ((h as f64 * scale).round() as i32).max(side);
+    let scale = (frame_w as f64 / w as f64).max(frame_h as f64 / h as f64);
+    let scaled_w = ((w as f64 * scale).round() as i32).max(frame_w);
+    let scaled_h = ((h as f64 * scale).round() as i32).max(frame_h);
     let Some(scaled) = image.scale_simple(scaled_w, scaled_h, InterpType::Bilinear) else {
         return image.clone();
     };
     // Take the middle: a capture's edges are where its chrome is, and
-    // its middle is what it was taken of.
-    let x = ((scaled_w - side) / 2).max(0);
-    let y = ((scaled_h - side) / 2).max(0);
-    scaled.new_subpixbuf(x, y, side.min(scaled_w), side.min(scaled_h))
+    // its middle is what it was taken of. A capture shaped like the
+    // screen crops nothing, which is the point of the frame's shape.
+    let x = ((scaled_w - frame_w) / 2).max(0);
+    let y = ((scaled_h - frame_h) / 2).max(0);
+    scaled.new_subpixbuf(x, y, frame_w.min(scaled_w), frame_h.min(scaled_h))
 }
 
 /// The hover toolbar: edit, copy, copy path, close.
@@ -611,8 +632,8 @@ fn target_origin(gesture: &gtk::GestureClick) -> Option<(f64, f64)> {
 #[cfg(test)]
 mod tests {
     use super::{
-        DRAG_ICON_MAX, EDGE_MARGIN, PIN_PADDING, PIN_SIDE, cover_thumbnail, first_free_slot,
-        fit_within, pin_step, slot_of,
+        DRAG_ICON_MAX, EDGE_MARGIN, PIN_PADDING, cover_thumbnail, first_free_slot, fit_within,
+        pin_size, pin_step, slot_of,
     };
     use relm4::gtk::gdk_pixbuf::{Colorspace, Pixbuf};
 
@@ -644,25 +665,43 @@ mod tests {
     /// inside it: a wide capture letterboxed into a sliver is
     /// unrecognisable, which defeats having a pin at all.
     #[test]
-    fn a_wide_capture_fills_the_square() {
-        let wide = Pixbuf::new(Colorspace::Rgb, true, 8, 1600, 400).unwrap();
-        let thumb = cover_thumbnail(&wide, PIN_SIDE);
-        assert_eq!((thumb.width(), thumb.height()), (PIN_SIDE, PIN_SIDE));
+    fn a_wide_capture_fills_the_frame() {
+        let frame = (224, 126);
+        let wide = Pixbuf::new(Colorspace::Rgb, true, 8, 4000, 400).unwrap();
+        let thumb = cover_thumbnail(&wide, frame);
+        assert_eq!((thumb.width(), thumb.height()), frame);
     }
 
     /// A tall stitch is cropped to its middle for the same reason.
     #[test]
-    fn a_tall_capture_fills_the_square() {
+    fn a_tall_capture_fills_the_frame() {
+        let frame = (224, 126);
         let tall = Pixbuf::new(Colorspace::Rgb, true, 8, 600, 9000).unwrap();
-        let thumb = cover_thumbnail(&tall, PIN_SIDE);
-        assert_eq!((thumb.width(), thumb.height()), (PIN_SIDE, PIN_SIDE));
+        let thumb = cover_thumbnail(&tall, frame);
+        assert_eq!((thumb.width(), thumb.height()), frame);
+    }
+
+    /// A capture shaped like the screen loses nothing: the frame is
+    /// that shape, which is the reason it is.
+    #[test]
+    fn a_full_screen_capture_is_not_cropped() {
+        let frame = (224, 126);
+        // Same 16:9 as the frame, at capture resolution.
+        let full = Pixbuf::new(Colorspace::Rgb, true, 8, 6144, 3456).unwrap();
+        let thumb = cover_thumbnail(&full, frame);
+        assert_eq!((thumb.width(), thumb.height()), frame);
+        // Cover-scaling a matching aspect needs no crop in either
+        // direction: the scale factors agree.
+        let sx = frame.0 as f64 / 6144.0;
+        let sy = frame.1 as f64 / 3456.0;
+        assert!((sx - sy).abs() < 0.001, "{sx} vs {sy}");
     }
 
     /// Pins stack clear of each other, so a second one doesn't bury
     /// the first — seeing both is the point of stacking them.
     #[test]
     fn stacked_pins_do_not_overlap() {
-        assert!(pin_step() > PIN_SIDE + PIN_PADDING * 2);
+        assert!(pin_step() > pin_size().1 + PIN_PADDING * 2);
     }
 
     /// A pin sitting in the column is recognised as being in its slot,
@@ -670,9 +709,10 @@ mod tests {
     #[test]
     fn a_pin_in_the_column_holds_its_slot() {
         let screen = (3072, 1728);
-        let side = PIN_SIDE + PIN_PADDING * 2;
+        let (frame_w, frame_h) = pin_size();
+        let side = frame_w + PIN_PADDING * 2;
         let x = screen.0 - EDGE_MARGIN - side;
-        let base = screen.1 - EDGE_MARGIN - side;
+        let base = screen.1 - EDGE_MARGIN - (frame_h + PIN_PADDING * 2);
         assert_eq!(slot_of((x, base, side, side), screen), Some(0));
         assert_eq!(slot_of((x, base - pin_step(), side, side), screen), Some(1));
     }
@@ -683,9 +723,10 @@ mod tests {
     #[test]
     fn a_moved_pin_frees_its_slot() {
         let screen = (3072, 1728);
-        let side = PIN_SIDE + PIN_PADDING * 2;
+        let (frame_w, frame_h) = pin_size();
+        let side = frame_w + PIN_PADDING * 2;
         let x = screen.0 - EDGE_MARGIN - side;
-        let base = screen.1 - EDGE_MARGIN - side;
+        let base = screen.1 - EDGE_MARGIN - (frame_h + PIN_PADDING * 2);
         // Dragged left, and dragged up between two slots.
         assert_eq!(slot_of((x - 300, base, side, side), screen), None);
         assert_eq!(slot_of((x, base - pin_step() / 2, side, side), screen), None);

--- a/src/pin.rs
+++ b/src/pin.rs
@@ -54,11 +54,6 @@ fn pin_size() -> (i32, i32) {
     (PIN_WIDTH, height)
 }
 
-/// Frame around the preview: the pin needs an edge of its own or it
-/// reads as a picture lying loose on the desktop rather than a thing
-/// sitting on it.
-const PIN_PADDING: i32 = 6;
-
 /// The move handle's tooltip, named because the drag hides it and has
 /// to put it back.
 const MOVE_TOOLTIP: &str = "Move this pin";
@@ -134,7 +129,7 @@ pub fn open(image: &Pixbuf, actions: PinActions) -> Pin {
     window.add_css_class("pin-window");
 
     let (frame_w, frame_h) = pin_size();
-    window.set_default_size(frame_w + PIN_PADDING * 2, frame_h + PIN_PADDING * 2);
+    window.set_default_size(frame_w, frame_h);
 
     // Float it, show it on every workspace, and put it in its slot —
     // once it has a surface for the compositor to match on.
@@ -177,15 +172,13 @@ pub fn open(image: &Pixbuf, actions: PinActions) -> Pin {
     picture.set_can_shrink(true);
     picture.set_size_request(frame_w, frame_h);
 
-    // No border of our own: the compositor draws one around a
-    // floating window, and two frames around one picture is one frame
-    // too many.
-    let frame = gtk::Box::new(gtk::Orientation::Horizontal, 0);
-    frame.add_css_class("pin-frame");
-    frame.append(&picture);
-
+    // The picture is the whole window. The compositor draws the border
+    // and the shadow around a floating window, so a mat and a rounded
+    // corner of our own are a second frame inside the first — and the
+    // dark edge they leave reads as part of the shot rather than as
+    // part of the desktop.
     let overlay = gtk::Overlay::new();
-    overlay.set_child(Some(&frame));
+    overlay.set_child(Some(&picture));
 
     // The picture and the Edit button do the same thing, so they share
     // one callback rather than each getting a copy of the intent.
@@ -332,8 +325,8 @@ fn place_in_slot(slot: i32) {
         (monitor.height as f64 / scale).round() as i32,
     );
     let (frame_w, frame_h) = pin_size();
-    let x = screen_w - EDGE_MARGIN - (frame_w + PIN_PADDING * 2);
-    let y = screen_h - EDGE_MARGIN - (frame_h + PIN_PADDING * 2) - slot * pin_step();
+    let x = screen_w - EDGE_MARGIN - frame_w;
+    let y = screen_h - EDGE_MARGIN - frame_h - slot * pin_step();
     hypr_dispatch(&format!(
         "hl.dsp.window.move({{ x = {x}, y = {y}, relative = false, {} }})",
         pin_selector()
@@ -342,7 +335,7 @@ fn place_in_slot(slot: i32) {
 
 /// How far apart stacked pins sit, centre to centre.
 fn pin_step() -> i32 {
-    pin_size().1 + PIN_PADDING * 2 + PIN_GAP
+    pin_size().1 + PIN_GAP
 }
 
 /// The slot a pin at `rect` is sitting in, or `None` if it isn't in
@@ -358,10 +351,10 @@ fn slot_of(rect: (i32, i32, i32, i32), screen: (i32, i32)) -> Option<i32> {
     const TOLERANCE: i32 = 4;
     let (frame_w, frame_h) = pin_size();
     let (x, y, _, _) = rect;
-    if (x - (screen.0 - EDGE_MARGIN - (frame_w + PIN_PADDING * 2))).abs() > TOLERANCE {
+    if (x - (screen.0 - EDGE_MARGIN - frame_w)).abs() > TOLERANCE {
         return None;
     }
-    let base = screen.1 - EDGE_MARGIN - (frame_h + PIN_PADDING * 2);
+    let base = screen.1 - EDGE_MARGIN - frame_h;
     let step = pin_step();
     let index = ((base - y) as f64 / step as f64).round() as i32;
     let expected = base - index * step;
@@ -632,8 +625,8 @@ fn target_origin(gesture: &gtk::GestureClick) -> Option<(f64, f64)> {
 #[cfg(test)]
 mod tests {
     use super::{
-        DRAG_ICON_MAX, EDGE_MARGIN, PIN_PADDING, cover_thumbnail, first_free_slot, fit_within,
-        pin_size, pin_step, slot_of,
+        DRAG_ICON_MAX, EDGE_MARGIN, cover_thumbnail, first_free_slot, fit_within, pin_size,
+        pin_step, slot_of,
     };
     use relm4::gtk::gdk_pixbuf::{Colorspace, Pixbuf};
 
@@ -701,7 +694,7 @@ mod tests {
     /// the first — seeing both is the point of stacking them.
     #[test]
     fn stacked_pins_do_not_overlap() {
-        assert!(pin_step() > pin_size().1 + PIN_PADDING * 2);
+        assert!(pin_step() > pin_size().1);
     }
 
     /// A pin sitting in the column is recognised as being in its slot,
@@ -710,9 +703,9 @@ mod tests {
     fn a_pin_in_the_column_holds_its_slot() {
         let screen = (3072, 1728);
         let (frame_w, frame_h) = pin_size();
-        let side = frame_w + PIN_PADDING * 2;
+        let side = frame_w;
         let x = screen.0 - EDGE_MARGIN - side;
-        let base = screen.1 - EDGE_MARGIN - (frame_h + PIN_PADDING * 2);
+        let base = screen.1 - EDGE_MARGIN - frame_h;
         assert_eq!(slot_of((x, base, side, side), screen), Some(0));
         assert_eq!(slot_of((x, base - pin_step(), side, side), screen), Some(1));
     }
@@ -724,9 +717,9 @@ mod tests {
     fn a_moved_pin_frees_its_slot() {
         let screen = (3072, 1728);
         let (frame_w, frame_h) = pin_size();
-        let side = frame_w + PIN_PADDING * 2;
+        let side = frame_w;
         let x = screen.0 - EDGE_MARGIN - side;
-        let base = screen.1 - EDGE_MARGIN - (frame_h + PIN_PADDING * 2);
+        let base = screen.1 - EDGE_MARGIN - frame_h;
         // Dragged left, and dragged up between two slots.
         assert_eq!(slot_of((x - 300, base, side, side), screen), None);
         assert_eq!(slot_of((x, base - pin_step() / 2, side, side), screen), None);

--- a/src/pin.rs
+++ b/src/pin.rs
@@ -49,6 +49,11 @@ const MOVE_TOOLTIP: &str = "Move this pin";
 /// same reason.
 const PICTURE_TOOLTIP: &str = "Click to open in the editor · Drag into another app to paste it";
 
+/// How often a dragged pin asks where the pointer is. 16ms is a frame
+/// at 60Hz: often enough to look attached, rare enough that the socket
+/// round-trip costs nothing.
+const FOLLOW_INTERVAL: Duration = Duration::from_millis(16);
+
 /// Gap between stacked pins.
 const PIN_GAP: i32 = 12;
 
@@ -482,49 +487,77 @@ fn fit_within(width: i32, height: i32, max: i32) -> (i32, i32) {
 fn install_move(window: &gtk::Window, target: &gtk::Button, bottom_margin: i32) {
     let right = Rc::new(Cell::new(EDGE_MARGIN));
     let bottom = Rc::new(Cell::new(bottom_margin));
+    let dragging = Rc::new(Cell::new(false));
 
-    let drag = gtk::GestureDrag::new();
+    let press = gtk::GestureClick::new();
     {
-        // A moving window can't be dragged from a fixed reference.
-        // The gesture measures its delta inside this window's own
-        // coordinates, so every step the window takes is subtracted
-        // from the next reading: applied against the position the drag
-        // started from, the window catches up, the delta falls back to
-        // zero, and it springs to where it began — which is the lag,
-        // and the shake.
-        //
-        // Applying each reading to the CURRENT position instead is
-        // self-correcting: moving the window zeroes the delta, so the
-        // next reading is exactly the new pointer motion and nothing
-        // else.
         let window = window.clone();
+        let target_press = target.clone();
         let right = right.clone();
         let bottom = bottom.clone();
-        drag.connect_drag_update(move |_, dx, dy| {
-            // Clamped at zero so a drag can't push the pin off the
-            // edge it is anchored to and out of reach.
-            let new_right = (right.get() - dx.round() as i32).max(0);
-            let new_bottom = (bottom.get() - dy.round() as i32).max(0);
-            right.set(new_right);
-            bottom.set(new_bottom);
-            window.set_margin(Edge::Right, new_right);
-            window.set_margin(Edge::Bottom, new_bottom);
+        let dragging = dragging.clone();
+        press.connect_pressed(move |_, _, _, _| {
+            // Where the pointer is and where the pin is, both in the
+            // compositor's own coordinates. Everything after this is
+            // arithmetic on those two.
+            let Some(origin) = crate::hypr::cursor_position() else {
+                return;
+            };
+            if dragging.replace(true) {
+                return;
+            }
+            // The tooltip would otherwise reappear on every step: the
+            // window slides out from under the pointer, which GTK
+            // reads as a fresh hover.
+            target_press.set_has_tooltip(false);
+
+            let start = (right.get(), bottom.get());
+            let window = window.clone();
+            let target_tick = target_press.clone();
+            let right = right.clone();
+            let bottom = bottom.clone();
+            let dragging = dragging.clone();
+            // A timer, not motion events: the pointer leaves the
+            // handle the moment the window lags behind it, and a drag
+            // that stops when it falls behind is exactly the drag that
+            // was falling behind.
+            gtk::glib::timeout_add_local(FOLLOW_INTERVAL, move || {
+                if !dragging.get() {
+                    target_tick.set_tooltip_text(Some(MOVE_TOOLTIP));
+                    return gtk::glib::ControlFlow::Break;
+                }
+                let Some((x, y)) = crate::hypr::cursor_position() else {
+                    return gtk::glib::ControlFlow::Continue;
+                };
+                // Anchored bottom-right, so a rightward move shrinks
+                // the right margin. Clamped so a pin can't be pushed
+                // off the edge it hangs from and out of reach.
+                let new_right = (start.0 - (x - origin.0)).max(0);
+                let new_bottom = (start.1 - (y - origin.1)).max(0);
+                if (new_right, new_bottom) != (right.get(), bottom.get()) {
+                    right.set(new_right);
+                    bottom.set(new_bottom);
+                    window.set_margin(Edge::Right, new_right);
+                    window.set_margin(Edge::Bottom, new_bottom);
+                }
+                gtk::glib::ControlFlow::Continue
+            });
         });
     }
     {
-        // The window slides out from under the pointer while dragging,
-        // which GTK reads as a fresh hover on every step: the tooltip
-        // pops back and jitters along beside the pin.
-        let target_begin = target.clone();
-        drag.connect_drag_begin(move |_, _, _| target_begin.set_has_tooltip(false));
+        let dragging = dragging.clone();
+        press.connect_released(move |_, _, _, _| dragging.set(false));
     }
+    // A pointer that leaves without a release — the window outrunning
+    // it, a compositor grab ending — must still finish the drag, or
+    // the pin follows the cursor forever.
     {
-        let target_end = target.clone();
-        drag.connect_drag_end(move |_, _, _| {
-            target_end.set_tooltip_text(Some(MOVE_TOOLTIP));
-        });
+        let dragging = dragging.clone();
+        let cancel = gtk::EventControllerMotion::new();
+        cancel.connect_leave(move |_| dragging.set(false));
+        target.add_controller(cancel);
     }
-    target.add_controller(drag);
+    target.add_controller(press);
 }
 
 #[cfg(test)]

--- a/src/pin.rs
+++ b/src/pin.rs
@@ -27,9 +27,18 @@ use std::rc::Rc;
 use std::time::Duration;
 
 /// Width of a pinned capture, in CSS pixels. Height follows the
-/// image's aspect. Big enough to read a line of text in a terminal
-/// shot, small enough to leave the desktop usable.
-const PIN_WIDTH: i32 = 280;
+/// image's aspect. Big enough to tell one shot from another, small
+/// enough to leave the desktop usable — a pin is a reminder of what
+/// you took, not a window to work in.
+const PIN_WIDTH: i32 = 186;
+
+/// Frame around the preview: the pin needs an edge of its own or it
+/// reads as a picture lying loose on the desktop rather than a thing
+/// sitting on it.
+const PIN_PADDING: i32 = 6;
+
+/// Gap between stacked pins.
+const PIN_GAP: i32 = 12;
 
 /// Gap between the pin and the screen edge it starts anchored to.
 const EDGE_MARGIN: i32 = 24;
@@ -93,26 +102,39 @@ pub fn open(image: &Pixbuf, actions: PinActions) -> Pin {
     window.set_layer(Layer::Overlay);
     window.set_anchor(Edge::Right, true);
     window.set_anchor(Edge::Bottom, true);
+    window.set_namespace(Some(PIN_NAMESPACE));
+    // Stack above whatever is already pinned instead of landing on
+    // top of it. Each capture is its own process, so the count comes
+    // from the compositor rather than from a shared list.
+    let (width, height) = scaled_size(image.width(), image.height());
+    let bottom = EDGE_MARGIN + stacked_pins() * (height + PIN_PADDING * 2 + PIN_GAP);
     window.set_margin(Edge::Right, EDGE_MARGIN);
-    window.set_margin(Edge::Bottom, EDGE_MARGIN);
+    window.set_margin(Edge::Bottom, bottom);
     // OnDemand rather than Exclusive: the pin should never swallow the
     // keystrokes of whatever the user is actually working in, but Esc
     // has to reach it once it is clicked.
     window.set_keyboard_mode(KeyboardMode::OnDemand);
 
-    let (width, height) = scaled_size(image.width(), image.height());
-    window.set_default_size(width, height);
+    window.set_default_size(width + PIN_PADDING * 2, height + PIN_PADDING * 2);
 
-    let picture = gtk::Picture::for_pixbuf(image);
+    // Scale the pixels down rather than asking the widget to shrink
+    // them. A `Picture`'s natural size is its image's, so a 6K capture
+    // asked for a 6K surface and the compositor clamped it — which is
+    // why a pin showed a corner at full size instead of the shot.
+    let preview = image
+        .scale_simple(width, height, gtk::gdk_pixbuf::InterpType::Bilinear)
+        .unwrap_or_else(|| image.clone());
+    let picture = gtk::Picture::for_pixbuf(&preview);
     picture.set_can_shrink(true);
-    // `keep_aspect_ratio` in this GTK build; a long stitch is capped
-    // in `scaled_size`, so the picture letterboxes rather than
-    // stretching when the cap bites.
     picture.set_keep_aspect_ratio(true);
     picture.set_size_request(width, height);
 
+    let frame = gtk::Box::new(gtk::Orientation::Horizontal, 0);
+    frame.add_css_class("pin-frame");
+    frame.append(&picture);
+
     let overlay = gtk::Overlay::new();
-    overlay.set_child(Some(&picture));
+    overlay.set_child(Some(&frame));
 
     let controls = build_controls(&window, image, actions);
     overlay.add_overlay(&controls);
@@ -170,6 +192,28 @@ fn build_toast() -> (gtk::Label, Toast) {
         });
     };
     (label, Rc::new(show))
+}
+
+/// Layer-surface namespace, so pins can count each other.
+const PIN_NAMESPACE: &str = "tensaku-pin";
+
+/// How many pins are already on screen.
+///
+/// Asks the compositor rather than keeping a count: every capture is a
+/// separate process, and a file of slots would go stale the first time
+/// one crashed. A compositor that can't be asked answers zero, and the
+/// new pin lands in the corner like the first one.
+fn stacked_pins() -> i32 {
+    let Ok(output) = std::process::Command::new("hyprctl")
+        .args(["-j", "layers"])
+        .output()
+    else {
+        return 0;
+    };
+    let Ok(text) = String::from_utf8(output.stdout) else {
+        return 0;
+    };
+    text.matches(PIN_NAMESPACE).count() as i32
 }
 
 /// Fit `PIN_WIDTH` while keeping the capture's aspect, and never let a
@@ -352,7 +396,7 @@ fn install_drag(window: &gtk::Window, target: &gtk::Overlay) {
 
 #[cfg(test)]
 mod tests {
-    use super::{DRAG_ICON_MAX, PIN_WIDTH, fit_within, scaled_size};
+    use super::{DRAG_ICON_MAX, PIN_GAP, PIN_PADDING, PIN_WIDTH, fit_within, scaled_size};
 
     /// The pointer carries a token, not the capture: a 6K shot has to
     /// come down to something a pointer can drag.
@@ -397,5 +441,15 @@ mod tests {
     fn a_long_stitch_is_capped() {
         let (_, h) = scaled_size(1000, 40_000);
         assert_eq!(h, PIN_WIDTH * 3);
+    }
+
+    /// Pins stack clear of each other, so a second one doesn't bury
+    /// the first — the whole point of seeing both is telling them
+    /// apart.
+    #[test]
+    fn stacked_pins_do_not_overlap() {
+        let (_, height) = scaled_size(1600, 900);
+        let step = height + PIN_PADDING * 2 + PIN_GAP;
+        assert!(step > height + PIN_PADDING * 2);
     }
 }

--- a/src/pin.rs
+++ b/src/pin.rs
@@ -1,23 +1,33 @@
 //! Pin the finished shot to the desktop.
 //!
-//! A pinned capture is a small always-on-top window in a corner of the
-//! screen, showing what the editor produced. It exists so a reference
-//! can stay visible while you work in another window — the thing a
-//! screenshot is usually *for* — instead of living in a file you have
-//! to keep re-opening.
+//! A pinned capture is a small window in the corner of the screen
+//! showing what the editor produced. It exists so a reference can stay
+//! visible while you work in another window — the thing a screenshot
+//! is usually *for* — instead of living in a file you have to keep
+//! re-opening.
 //!
 //! Two decisions worth knowing:
 //!
-//! - **It is a layer surface**, like the scroll-capture overlay, which
-//!   is what keeps it above ordinary windows without asking the
-//!   compositor for a rule. A layer surface has no titlebar and the
-//!   compositor won't move it, so dragging is implemented here by
-//!   walking the anchor margins.
+//! - **It is an ordinary floating window**, and its handle asks the
+//!   compositor to drag it. A compositor moves a floating window
+//!   during its own frame with the client out of the loop, which is
+//!   why that feels instant; a client-positioned surface — which is
+//!   what this was, as a layer surface walking its own anchor margins
+//!   — cannot be anywhere but a round trip behind the pointer.
 //! - **Edit keeps the annotations live.** The pin and the editor are
 //!   the same process, so Edit hides the pin and shows the editor
 //!   window again with every drawable still where it was, still
 //!   movable. Nothing is serialised and nothing is flattened; the
 //!   cost is that the pin lasts as long as the process does.
+//!
+//! Off Hyprland it degrades rather than breaking. The drag is the
+//! standard `xdg_toplevel.move` request that every compositor
+//! implements, so it works anywhere. Floating, pinning across
+//! workspaces and landing in a corner slot are Hyprland dispatchers,
+//! and a Wayland client cannot place itself without something like
+//! them: elsewhere the pin opens wherever the compositor decides, and
+//! draws its own border, since nothing promises one around an
+//! undecorated window.
 
 use crate::ui::toolbars::RobustTooltipExt;
 use relm4::gtk::gdk_pixbuf::InterpType;
@@ -133,7 +143,7 @@ pub fn open(image: &Pixbuf, actions: PinActions) -> Pin {
 
     // Float it, show it on every workspace, and put it in its slot —
     // once it has a surface for the compositor to match on.
-    {
+    if on_hyprland() {
         let slot = next_slot();
         window.connect_map(move |_| {
             // Not immediately: `map` is this side's word for "shown",
@@ -172,13 +182,22 @@ pub fn open(image: &Pixbuf, actions: PinActions) -> Pin {
     picture.set_can_shrink(true);
     picture.set_size_request(frame_w, frame_h);
 
-    // The picture is the whole window. The compositor draws the border
-    // and the shadow around a floating window, so a mat and a rounded
-    // corner of our own are a second frame inside the first — and the
-    // dark edge they leave reads as part of the shot rather than as
-    // part of the desktop.
+    // On Hyprland the picture is the whole window: the compositor
+    // draws the border and the shadow around a floating window, and a
+    // mat of our own would be a second frame inside the first.
+    //
+    // Elsewhere there is no such promise for an undecorated window, so
+    // the pin brings its own edge rather than reading as a picture
+    // lying loose on the desktop.
     let overlay = gtk::Overlay::new();
-    overlay.set_child(Some(&picture));
+    if on_hyprland() {
+        overlay.set_child(Some(&picture));
+    } else {
+        let frame = gtk::Box::new(gtk::Orientation::Horizontal, 0);
+        frame.add_css_class("pin-frame");
+        frame.append(&picture);
+        overlay.set_child(Some(&frame));
+    }
 
     // The picture and the Edit button do the same thing, so they share
     // one callback rather than each getting a copy of the intent.
@@ -277,6 +296,15 @@ fn pin_title() -> String {
     // The process id is enough: a capture is a process, and a process
     // has one pin.
     format!("{PIN_TITLE} {}", std::process::id())
+}
+
+/// Whether the compositor is Hyprland, and so whether the pin can ask
+/// to be floated, pinned and placed.
+///
+/// Everything gated on this is a nicety: without it the pin still
+/// opens, still drags, and still does everything its toolbar offers.
+fn on_hyprland() -> bool {
+    std::env::var_os("HYPRLAND_INSTANCE_SIGNATURE").is_some()
 }
 
 /// Run one Hyprland dispatcher, best-effort.
@@ -584,12 +612,14 @@ fn install_move(window: &gtk::Window, target: &gtk::Button) {
     let press = gtk::GestureClick::new();
     let window = window.clone();
     press.connect_pressed(move |gesture, _, x, y| {
-        // Hand the drag to the compositor. Hyprland moves a floating
-        // window during its own frame, with the client out of the
-        // loop, which is why dragging one feels instant and why every
-        // attempt to move this window ourselves trailed by a frame:
-        // a client-positioned surface cannot be anywhere but one round
-        // trip behind the pointer.
+        // Hand the drag to the compositor. It moves the window during
+        // its own frame with the client out of the loop, which is why
+        // this feels instant where every attempt to move the window
+        // ourselves trailed: a client-positioned surface cannot be
+        // anywhere but one round trip behind the pointer.
+        //
+        // `xdg_toplevel.move` is the standard request every compositor
+        // implements, so this much works off Hyprland too.
         crate::ui::toolbars::dismiss_active_tooltip();
         let Some(surface) = window.surface() else {
             return;

--- a/src/pin.rs
+++ b/src/pin.rs
@@ -23,7 +23,9 @@ use crate::ui::toolbars::RobustTooltipExt;
 use gtk4_layer_shell::{Edge, KeyboardMode, Layer, LayerShell};
 use relm4::gtk::gdk_pixbuf::InterpType;
 use relm4::gtk::{self, gdk_pixbuf::Pixbuf, prelude::*};
-use std::cell::Cell;
+use std::cell::{Cell, RefCell};
+use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, AtomicI32, Ordering};
 use std::rc::Rc;
 use std::time::Duration;
 
@@ -49,13 +51,12 @@ const MOVE_TOOLTIP: &str = "Move this pin";
 /// same reason.
 const PICTURE_TOOLTIP: &str = "Click to open in the editor · Drag into another app to paste it";
 
-/// How often a dragged pin asks where the pointer is.
+/// How often the follower thread reads the pointer.
 ///
-/// Twice a frame at 60Hz. The cost is a socket round-trip, which is
-/// sub-millisecond; the win is that a step is never more than half a
-/// frame stale before it is drawn, which is the difference between a
-/// pin that feels attached to the pointer and one that trails it.
-const FOLLOW_INTERVAL: Duration = Duration::from_millis(8);
+/// Far faster than a frame, because it costs nothing on the UI thread:
+/// whatever the compositor answers, the freshest reading is already
+/// waiting when the next frame asks for it.
+const POLL_INTERVAL: Duration = Duration::from_millis(2);
 
 /// Gap between stacked pins.
 const PIN_GAP: i32 = 12;
@@ -482,48 +483,61 @@ fn fit_within(width: i32, height: i32, max: i32) -> (i32, i32) {
 fn install_move(window: &gtk::Window, target: &gtk::Button, bottom_margin: i32) {
     let right = Rc::new(Cell::new(EDGE_MARGIN));
     let bottom = Rc::new(Cell::new(bottom_margin));
-    let dragging = Rc::new(Cell::new(false));
 
     let press = gtk::GestureClick::new();
     {
         let window = window.clone();
         let right = right.clone();
         let bottom = bottom.clone();
-        let dragging = dragging.clone();
         press.connect_pressed(move |_, _, _, _| {
-            // Where the pointer is and where the pin is, both in the
-            // compositor's own coordinates. Everything after this is
-            // arithmetic on those two.
             let Some(origin) = crate::hypr::cursor_position() else {
                 return;
             };
-            if dragging.replace(true) {
-                return;
+            let start = (right.get(), bottom.get());
+
+            // The pointer is read on a thread of its own. Asking for
+            // it inline stalled the UI thread for five milliseconds at
+            // the ninetieth percentile — the compositor answers slowly
+            // exactly when it is busy, which is precisely when we have
+            // just asked it to move a window. Off-thread, the answer
+            // is always waiting and never in the way.
+            let cursor = Arc::new(CursorFollow::new(origin));
+            {
+                let cursor = Arc::clone(&cursor);
+                std::thread::spawn(move || {
+                    while cursor.following.load(Ordering::Relaxed) {
+                        if let Some((x, y)) = crate::hypr::cursor_position() {
+                            cursor.x.store(x, Ordering::Relaxed);
+                            cursor.y.store(y, Ordering::Relaxed);
+                        }
+                        std::thread::sleep(POLL_INTERVAL);
+                    }
+                });
             }
 
-            let start = (right.get(), bottom.get());
-            let window = window.clone();
             let right = right.clone();
             let bottom = bottom.clone();
-            let dragging = dragging.clone();
-            // A timer, not motion events: the pointer leaves the
-            // handle the moment the window lags behind it, and a drag
-            // that stops when it falls behind is exactly the drag that
-            // was falling behind.
-            gtk::glib::timeout_add_local(FOLLOW_INTERVAL, move || {
-                if !dragging.get() {
+            let cursor_for_tick = Arc::clone(&cursor);
+            // On the frame clock rather than a timer: a margin can
+            // only take effect on a frame, so setting it more often
+            // than that is work the compositor throws away, and
+            // setting it on any other cadence means landing a step
+            // late.
+            window.add_tick_callback(move |window, _| {
+                if !cursor_for_tick.following.load(Ordering::Relaxed) {
+                    crate::ui::toolbars::dismiss_active_tooltip();
                     return gtk::glib::ControlFlow::Break;
                 }
-                // Every tick, because the pointer never leaves the
-                // handle during a drag: nothing else would take the
-                // tooltip down, and it would tag along beside the pin.
+                // Every frame: the pointer never leaves the handle
+                // during a drag, so nothing else takes the tooltip
+                // down.
                 crate::ui::toolbars::dismiss_active_tooltip();
-                let Some((x, y)) = crate::hypr::cursor_position() else {
-                    return gtk::glib::ControlFlow::Continue;
-                };
-                // Anchored bottom-right, so a rightward move shrinks
-                // the right margin. Clamped so a pin can't be pushed
-                // off the edge it hangs from and out of reach.
+
+                let x = cursor_for_tick.x.load(Ordering::Relaxed);
+                let y = cursor_for_tick.y.load(Ordering::Relaxed);
+                // Anchored bottom-right, so moving right shrinks the
+                // right margin. Clamped so a pin can't be pushed off
+                // the edge it hangs from and out of reach.
                 let new_right = (start.0 - (x - origin.0)).max(0);
                 let new_bottom = (start.1 - (y - origin.1)).max(0);
                 if (new_right, new_bottom) != (right.get(), bottom.get()) {
@@ -534,22 +548,55 @@ fn install_move(window: &gtk::Window, target: &gtk::Button, bottom_margin: i32) 
                 }
                 gtk::glib::ControlFlow::Continue
             });
+            // The gesture's own end, and a pointer that leaves without
+            // one — a compositor grab ending, the window outrunning the
+            // pointer — both have to stop the follow, or the pin
+            // chases the cursor forever.
+            let stop = Arc::clone(&cursor);
+            RELEASE.with(|slot| *slot.borrow_mut() = Some(stop));
         });
     }
     {
-        let dragging = dragging.clone();
-        press.connect_released(move |_, _, _, _| dragging.set(false));
+        press.connect_released(|_, _, _, _| stop_following());
     }
-    // A pointer that leaves without a release — the window outrunning
-    // it, a compositor grab ending — must still finish the drag, or
-    // the pin follows the cursor forever.
     {
-        let dragging = dragging.clone();
         let cancel = gtk::EventControllerMotion::new();
-        cancel.connect_leave(move |_| dragging.set(false));
+        cancel.connect_leave(|_| stop_following());
         target.add_controller(cancel);
     }
     target.add_controller(press);
+}
+
+/// The pointer position a drag is following, shared with the thread
+/// that reads it.
+struct CursorFollow {
+    x: AtomicI32,
+    y: AtomicI32,
+    following: AtomicBool,
+}
+
+impl CursorFollow {
+    fn new(origin: (i32, i32)) -> Self {
+        Self {
+            x: AtomicI32::new(origin.0),
+            y: AtomicI32::new(origin.1),
+            following: AtomicBool::new(true),
+        }
+    }
+}
+
+thread_local! {
+    /// The drag in progress, so a release or a stray leave can end it.
+    /// One pin per process, and one drag at a time within it.
+    static RELEASE: RefCell<Option<Arc<CursorFollow>>> = const { RefCell::new(None) };
+}
+
+fn stop_following() {
+    RELEASE.with(|slot| {
+        if let Some(cursor) = slot.borrow_mut().take() {
+            cursor.following.store(false, Ordering::Relaxed);
+        }
+    });
 }
 
 #[cfg(test)]

--- a/src/region_capture.rs
+++ b/src/region_capture.rs
@@ -73,10 +73,10 @@ impl Mode {
     fn hint(self) -> &'static str {
         match self {
             Mode::Area => {
-                "Drag to select  ·  Space: window  ·  F: full screen  ·  S: scrolling  ·  Esc"
+                "Drag to select  ·  Space: window  ·  R: last region  ·  F: full screen  ·  S: scrolling  ·  Esc"
             }
             Mode::Window => {
-                "Click a window  ·  Space: back to area  ·  F: full screen  ·  S: scrolling  ·  Esc"
+                "Click a window  ·  Space: area  ·  R: last region  ·  F: full screen  ·  S: scrolling  ·  Esc"
             }
         }
     }
@@ -433,10 +433,23 @@ fn to_image_rect(rect: Rect, scale: f64, frozen: &Pixbuf) -> Rect {
 }
 
 /// The choice a commit would make right now, in image pixels.
+///
+/// Remembers the logical rectangle on the way out, so the next capture
+/// can restore it: the saved value has to be in the overlay's own
+/// coordinates, since that is what a restored selection is drawn in.
 fn committed_region(state: &State) -> Option<RegionOutcome> {
-    let rect = pending_rect(state)?;
-    let rect = to_image_rect(rect, state.image_scale, &state.frozen);
-    (rect.width > 0 && rect.height > 0).then_some(RegionOutcome::Region(rect))
+    let logical = pending_rect(state)?;
+    let rect = to_image_rect(logical, state.image_scale, &state.frozen);
+    if rect.width <= 0 || rect.height <= 0 {
+        return None;
+    }
+    crate::state::save_capture_last_region([
+        logical.x as f64,
+        logical.y as f64,
+        logical.width as f64,
+        logical.height as f64,
+    ]);
+    Some(RegionOutcome::Region(rect))
 }
 
 fn install_pointer(
@@ -542,6 +555,31 @@ fn install_keys(
                     Some(choice) => finish(choice),
                     None => gtk::glib::Propagation::Stop,
                 }
+            }
+            // The last region, back as a live selection. Same shot
+            // twice means the same framing -- documentation sequences,
+            // before-and-afters -- without re-dragging it by eye and
+            // landing three pixels off.
+            gdk::Key::r | gdk::Key::R => {
+                let restored = crate::state::load_capture_last_region();
+                let Some([x, y, w, h]) = restored else {
+                    return gtk::glib::Propagation::Stop;
+                };
+                let mut state = state.borrow_mut();
+                state.mode = Mode::Area;
+                state.selection = Some(Rect {
+                    x: x.round() as i32,
+                    y: y.round() as i32,
+                    width: w.round() as i32,
+                    height: h.round() as i32,
+                });
+                // The readout follows the pointer during a drag; with
+                // nothing dragged, park it on the restored corner.
+                state.origin = (x, y);
+                state.pointer = (x + w, y + h);
+                hint.set_text(state.mode.hint());
+                layout_shade(&state);
+                gtk::glib::Propagation::Stop
             }
             gdk::Key::space => {
                 {

--- a/src/region_capture.rs
+++ b/src/region_capture.rs
@@ -41,6 +41,9 @@ const HINT_MARGIN_BOTTOM: i32 = 48;
 const GRIP: i32 = 12;
 const PUCK: i32 = 30;
 
+/// Space between the move puck and the capture button.
+const PUCK_GAP: f64 = 10.0;
+
 /// Ignore drags this small: a click that wobbles by a pixel is a click,
 /// and capturing a 3×2 region helps nobody.
 const MIN_DRAG: f64 = 8.0;
@@ -119,6 +122,10 @@ struct State {
     /// as a picture of where the last one was.
     grips: [gtk::Box; 8],
     puck: gtk::Box,
+    /// Take-the-shot button, beside the puck. A restored region is
+    /// framed and waiting; the keyboard says Enter, and this says the
+    /// same thing to a hand already on the mouse.
+    shutter: gtk::Button,
     /// The overlay's size in logical pixels, learned once it maps.
     size: (i32, i32),
     /// Image pixels per logical pixel, learned at draw time — the
@@ -218,10 +225,19 @@ fn build_overlay(
         puck.append(&cross);
     }
 
+    let shutter = gtk::Button::from_icon_name("camera-regular");
+    shutter.add_css_class("capture-shutter");
+    shutter.set_focusable(false);
+    shutter.set_focus_on_click(false);
+    shutter.set_tooltip_text(Some("Capture this region"));
+    shutter.set_size_request(PUCK, PUCK);
+    shutter.set_visible(false);
+
     let state = Rc::new(RefCell::new(State {
         frozen: frozen.clone(),
         grips: grips.clone(),
         puck: puck.clone(),
+        shutter: shutter.clone(),
         readout: readout.clone(),
         readout_label: readout_label.clone(),
         fixed: fixed.clone(),
@@ -281,7 +297,22 @@ fn build_overlay(
         fixed.put(grip, 0.0, 0.0);
     }
     fixed.put(&puck, 0.0, 0.0);
+    fixed.put(&shutter, 0.0, 0.0);
     overlay.add_overlay(&fixed);
+    {
+        // Commits exactly what Enter would, through the same path, so
+        // the two can't drift apart about what "this region" means.
+        let state_for_shutter = Rc::clone(&state);
+        let shared_for_shutter = Rc::clone(shared);
+        let window_for_shutter = window.clone();
+        shutter.connect_clicked(move |_| {
+            let choice = committed_region(&state_for_shutter.borrow());
+            if let Some(choice) = choice {
+                *shared_for_shutter.borrow_mut() = choice;
+                window_for_shutter.close();
+            }
+        });
+    }
     // The cursor goes on the widget the pointer is actually over, not
     // the window: GTK resolves it from the widget under the pointer
     // outward, and every event here lands on this surface.
@@ -309,6 +340,13 @@ fn build_overlay(
     overlay.add_overlay(&hint_pill);
     window.set_child(Some(&overlay));
 
+    // The icon bundle is registered by the editor's startup, which
+    // this path never runs — without it the capture button renders
+    // GTK's missing-image glyph.
+    relm4_icons::initialize_icons(
+        crate::icons::icon_names::GRESOURCE_BYTES,
+        crate::icons::icon_names::RESOURCE_PREFIX,
+    );
     install_css(app);
     install_pointer(&fixed, &state, &window, shared);
     install_keys(&window, &state, &hint, shared);
@@ -447,13 +485,20 @@ fn layout_grips(state: &State, rect: Rect) {
 
     // The puck needs room of its own — on a small region it would
     // cover the thing being framed.
-    let puck_fits = w > PUCK as f64 * 2.0 && h > PUCK as f64 * 2.0;
-    state.fixed.move_(
-        &state.puck,
-        x + w / 2.0 - PUCK as f64 / 2.0,
-        y + h / 2.0 - PUCK as f64 / 2.0,
-    );
-    state.puck.set_visible(puck_fits);
+    //
+    // The pair is centred together rather than the puck alone, so
+    // "move it" and "take it" read as one control rather than one
+    // control and an afterthought.
+    let pair = PUCK as f64 * 2.0 + PUCK_GAP;
+    let fits = w > pair + PUCK as f64 && h > PUCK as f64 * 2.0;
+    let top = y + h / 2.0 - PUCK as f64 / 2.0;
+    let left = x + w / 2.0 - pair / 2.0;
+    state.fixed.move_(&state.puck, left, top);
+    state.puck.set_visible(fits);
+    state
+        .fixed
+        .move_(&state.shutter, left + PUCK as f64 + PUCK_GAP, top);
+    state.shutter.set_visible(fits);
 }
 
 fn hide_grips(state: &State) {
@@ -461,6 +506,7 @@ fn hide_grips(state: &State) {
         grip.set_visible(false);
     }
     state.puck.set_visible(false);
+    state.shutter.set_visible(false);
 }
 
 /// Show the selection's size beside the corner being dragged.
@@ -843,6 +889,18 @@ fn install_css(app: &gtk::Application) {
              background: rgba(255, 255, 255, 0.92);
              border-radius: 3px;
              box-shadow: 0 1px 3px rgba(0, 0, 0, 0.5);
+         }
+         .capture-shutter {
+             background: rgba(20, 20, 26, 0.84);
+             border: 2px solid rgba(255, 255, 255, 0.92);
+             border-radius: 999px;
+             color: rgba(255, 255, 255, 0.92);
+             min-height: 0;
+             min-width: 0;
+             padding: 0;
+         }
+         .capture-shutter:hover {
+             background: rgba(60, 60, 70, 0.92);
          }
          .capture-puck {
              background: rgba(20, 20, 26, 0.84);

--- a/src/region_capture.rs
+++ b/src/region_capture.rs
@@ -222,15 +222,22 @@ fn build_overlay(
     // outward, and every event here lands on this surface.
     apply_cursor(&fixed, Mode::Area);
 
+    // The same pill the scrolling capture uses, down to the class
+    // names — the two overlays are one tool wearing two hats, and a
+    // second style for the same sentence would say otherwise.
     let hint = gtk::Label::new(Some(Mode::Area.hint()));
-    hint.add_css_class("region-capture-hint");
+    hint.add_css_class("scroll-capture-prompt-label");
+    let hint_pill = gtk::Box::new(gtk::Orientation::Horizontal, 0);
+    hint_pill.add_css_class("scroll-capture-pill");
+    hint_pill.add_css_class("scroll-capture-prompt");
+    hint_pill.append(&hint);
     // Centred on screen, like the scrolling capture's prompt: the
     // instructions are the only thing to read before a drag starts, so
     // they belong where the eye already is rather than in a corner it
     // has to find.
-    hint.set_halign(gtk::Align::Center);
-    hint.set_valign(gtk::Align::Center);
-    overlay.add_overlay(&hint);
+    hint_pill.set_halign(gtk::Align::Center);
+    hint_pill.set_valign(gtk::Align::Center);
+    overlay.add_overlay(&hint_pill);
     window.set_child(Some(&overlay));
 
     install_css(app);
@@ -543,12 +550,21 @@ fn install_css(app: &gtk::Application) {
          /* Faint enough to read the screen through, which is the point
             of lining up against it. */
          .region-capture-crosshair { background: rgba(255, 255, 255, 0.22); }
-         .region-capture-hint {
-             background: rgba(0, 0, 0, 0.75);
-             border-radius: 8px;
-             color: #ffffff;
-             font-size: 1.05em;
-             padding: 8px 16px;
+         /* Lifted from the scrolling capture's stylesheet: this
+            overlay is a separate GTK application with its own CSS, so
+            the rules have to exist in both places to look like one
+            tool. */
+         .scroll-capture-pill {
+             background-color: rgba(28, 28, 30, 0.92);
+             border-radius: 999px;
+             padding: 10px 18px;
+             border: 1px solid rgba(255, 255, 255, 0.08);
+             box-shadow: 0 6px 18px rgba(0, 0, 0, 0.45);
+         }
+         .scroll-capture-prompt-label {
+             color: rgba(245, 245, 247, 0.92);
+             font-size: 14px;
+             padding: 0 4px;
          }",
     );
     if let Some(display) = gdk::Display::default() {

--- a/src/region_capture.rs
+++ b/src/region_capture.rs
@@ -425,13 +425,12 @@ fn layout_shade(state: &State) {
     state.outline.set_size_request(w as i32, h as i32);
     state.fixed.move_(&state.outline, x, y);
     state.outline.set_visible(w >= 1.0 && h >= 1.0);
-    // Only while a drag is in flight: a restored region is a framing,
-    // not a measurement, and the pill would sit over the picture
-    // announcing a number nobody asked for.
-    if state.dragging {
+    // A fresh drag has no controls to anchor to, so the size follows
+    // the corner being pulled. Everything else — a restored region,
+    // one being moved or resized — has the control cluster, and the
+    // size belongs in it, holding still.
+    if fresh_drag(state) {
         layout_readout(state, rect);
-    } else {
-        state.readout.set_visible(false);
     }
     layout_grips(state, rect);
     // Once there is a rectangle, it is the thing being aimed — the
@@ -449,6 +448,12 @@ fn apply_cursor(widget: &gtk::Fixed, mode: Mode) {
     }));
 }
 
+/// Whether this drag is drawing a new rectangle rather than adjusting
+/// one that already exists.
+fn fresh_drag(state: &State) -> bool {
+    state.dragging && state.resize_handle.is_none()
+}
+
 /// Put the eight grips on the selection's edges and the puck at its
 /// middle, or hide them.
 ///
@@ -457,7 +462,7 @@ fn apply_cursor(widget: &gtk::Fixed, mode: Mode) {
 /// noise. Their positions are the same ones `hit_test_handle` answers
 /// for, so a grip is exactly where the grab is.
 fn layout_grips(state: &State, rect: Rect) {
-    if state.dragging || rect.width < 1 || rect.height < 1 {
+    if fresh_drag(state) || rect.width < 1 || rect.height < 1 {
         hide_grips(state);
         return;
     }
@@ -485,20 +490,35 @@ fn layout_grips(state: &State, rect: Rect) {
 
     // The puck needs room of its own — on a small region it would
     // cover the thing being framed.
-    //
-    // The pair is centred together rather than the puck alone, so
-    // "move it" and "take it" read as one control rather than one
-    // control and an afterthought.
-    let pair = PUCK as f64 * 2.0 + PUCK_GAP;
-    let fits = w > pair + PUCK as f64 && h > PUCK as f64 * 2.0;
-    let top = y + h / 2.0 - PUCK as f64 / 2.0;
-    let left = x + w / 2.0 - pair / 2.0;
-    state.fixed.move_(&state.puck, left, top);
-    state.puck.set_visible(fits);
+    let centre_x = x + w / 2.0;
+    let puck_top = y + h / 2.0 - PUCK as f64 / 2.0;
+    let fits = w > PUCK as f64 * 2.0 && h > PUCK as f64 * 2.0;
     state
         .fixed
-        .move_(&state.shutter, left + PUCK as f64 + PUCK_GAP, top);
-    state.shutter.set_visible(fits);
+        .move_(&state.puck, centre_x - PUCK as f64 / 2.0, puck_top);
+    state.puck.set_visible(fits);
+
+    // Size and shutter ride together under the puck, anchored to the
+    // region rather than to the pointer. They move when the region
+    // does and not otherwise: a number that jumps around while you are
+    // nudging a rectangle into place is harder to read than one that
+    // sits still.
+    state
+        .readout_label
+        .set_text(&format!("{} × {}", rect.width, rect.height));
+    let (_, pill_w, _, _) = state.readout.measure(gtk::Orientation::Horizontal, -1);
+    let (_, pill_h, _, _) = state.readout.measure(gtk::Orientation::Vertical, pill_w);
+    let row_w = pill_w as f64 + PUCK_GAP + PUCK as f64;
+    let row_x = centre_x - row_w / 2.0;
+    let row_y = puck_top + PUCK as f64 + PUCK_GAP;
+    let row_fits = fits && h > PUCK as f64 * 2.0 + pill_h as f64 + PUCK_GAP;
+
+    state.fixed.move_(&state.readout, row_x, row_y);
+    state.readout.set_visible(row_fits);
+    state
+        .fixed
+        .move_(&state.shutter, row_x + pill_w as f64 + PUCK_GAP, row_y);
+    state.shutter.set_visible(row_fits);
 }
 
 fn hide_grips(state: &State) {
@@ -508,6 +528,7 @@ fn hide_grips(state: &State) {
     state.puck.set_visible(false);
     state.shutter.set_visible(false);
 }
+
 
 /// Show the selection's size beside the corner being dragged.
 ///

--- a/src/region_capture.rs
+++ b/src/region_capture.rs
@@ -158,7 +158,7 @@ fn build_overlay(
 
     let crosshair: [gtk::Box; 2] = std::array::from_fn(|_| {
         let guide = gtk::Box::new(gtk::Orientation::Horizontal, 0);
-        guide.add_css_class("region-capture-crosshair");
+        guide.add_css_class("capture-crosshair");
         guide.set_visible(false);
         guide
     });
@@ -548,8 +548,9 @@ fn install_css(app: &gtk::Application) {
              border: 1px solid rgba(255, 255, 255, 0.9);
          }
          /* Faint enough to read the screen through, which is the point
-            of lining up against it. */
-         .region-capture-crosshair { background: rgba(255, 255, 255, 0.22); }
+            of lining up against it. Same class and colour in the
+            scrolling capture's stylesheet. */
+         .capture-crosshair { background: rgba(255, 255, 255, 0.22); }
          /* Lifted from the scrolling capture's stylesheet: this
             overlay is a separate GTK application with its own CSS, so
             the rules have to exist in both places to look like one

--- a/src/region_capture.rs
+++ b/src/region_capture.rs
@@ -313,13 +313,21 @@ fn build_overlay(
         let state_for_shutter = Rc::clone(&state);
         let shared_for_shutter = Rc::clone(shared);
         let window_for_shutter = window.clone();
-        readout.connect_clicked(move |_| {
+        // A GestureClick in the capture phase, not `connect_clicked`:
+        // the surface underneath carries the selection drag, and a
+        // press that reaches it first becomes a drag rather than a
+        // click on this button.
+        let press = gtk::GestureClick::new();
+        press.set_propagation_phase(gtk::PropagationPhase::Capture);
+        press.connect_pressed(move |gesture, _, _, _| {
+            gesture.set_state(gtk::EventSequenceState::Claimed);
             let choice = committed_region(&state_for_shutter.borrow());
             if let Some(choice) = choice {
                 *shared_for_shutter.borrow_mut() = choice;
                 window_for_shutter.close();
             }
         });
+        readout.add_controller(press);
     }
     // The cursor goes on the widget the pointer is actually over, not
     // the window: GTK resolves it from the widget under the pointer
@@ -848,10 +856,31 @@ pub fn readout_position(
     } else {
         corner.1 - GAP - readout.1
     };
-    (
-        x.clamp(0.0, (screen.0 - readout.0).max(0.0)),
-        y.clamp(0.0, (screen.1 - readout.1).max(0.0)),
-    )
+    // Off the edge, flip to the other side of the corner rather than
+    // sliding along it: a readout pinned to the screen edge ends up
+    // sitting on the selection it is measuring, which is the one place
+    // it must not be.
+    let x = if x < 0.0 || x + readout.0 > screen.0 {
+        let flipped = if corner.0 >= origin.0 {
+            corner.0 - GAP - readout.0
+        } else {
+            corner.0 + GAP
+        };
+        flipped.clamp(0.0, (screen.0 - readout.0).max(0.0))
+    } else {
+        x
+    };
+    let y = if y < 0.0 || y + readout.1 > screen.1 {
+        let flipped = if corner.1 >= origin.1 {
+            corner.1 - GAP - readout.1
+        } else {
+            corner.1 + GAP
+        };
+        flipped.clamp(0.0, (screen.1 - readout.1).max(0.0))
+    } else {
+        y
+    };
+    (x, y)
 }
 
 /// The scroll overlay's `Selection` for a `Rect`, and back. The two
@@ -999,9 +1028,10 @@ mod tests {
         // Dragging down-right: below and right of the corner.
         let (x, y) = readout_position((100.0, 100.0), (500.0, 400.0), size, screen);
         assert!(x > 500.0 && y > 400.0);
-        // Dragging up-left: above and left, clear of the corner.
-        let (x, y) = readout_position((500.0, 400.0), (100.0, 100.0), size, screen);
-        assert!(x + size.0 < 100.0 && y + size.1 < 100.0);
+        // Dragging up-left, with room on that side: above and left,
+        // clear of the corner. (Without room it flips — see below.)
+        let (x, y) = readout_position((1200.0, 900.0), (600.0, 500.0), size, screen);
+        assert!(x + size.0 < 600.0 && y + size.1 < 500.0);
     }
 
     /// The corner you drag is the one you drag off the screen, so the
@@ -1014,6 +1044,22 @@ mod tests {
         assert!(x + size.0 <= screen.0 && y + size.1 <= screen.1);
         let (x, y) = readout_position((500.0, 400.0), (0.0, 0.0), size, screen);
         assert!(x >= 0.0 && y >= 0.0);
+    }
+
+    /// At an edge it flips to the far side of the corner rather than
+    /// sliding along the edge — which would slide it onto the
+    /// selection it is measuring.
+    #[test]
+    fn the_readout_flips_at_an_edge() {
+        let screen = (2000.0, 1200.0);
+        let size = (90.0, 30.0);
+        // Dragging down-right into the bottom-right corner: the
+        // readout would land off-screen, so it moves above and left of
+        // the corner instead.
+        let corner = (1990.0, 1190.0);
+        let (x, y) = readout_position((100.0, 100.0), corner, size, screen);
+        assert!(x + size.0 <= corner.0, "expected a flip left of {corner:?}");
+        assert!(y + size.1 <= corner.1, "expected a flip above {corner:?}");
     }
 
     #[test]

--- a/src/region_capture.rs
+++ b/src/region_capture.rs
@@ -35,6 +35,12 @@ use crate::windows::{WindowTarget, visible_windows, window_at};
 /// scrolling capture's prompt, which sits at the same height.
 const HINT_MARGIN_BOTTOM: i32 = 48;
 
+/// Edge grip and move puck sizes, in logical pixels. The grips match
+/// the tolerance `hit_test_handle` already uses, so what you see is
+/// what you can grab.
+const GRIP: i32 = 12;
+const PUCK: i32 = 30;
+
 /// Ignore drags this small: a click that wobbles by a pixel is a click,
 /// and capturing a 3×2 region helps nobody.
 const MIN_DRAG: f64 = 8.0;
@@ -108,6 +114,11 @@ struct State {
     /// what the saved file will measure, not what the overlay shows.
     readout: gtk::Box,
     readout_label: gtk::Label,
+    /// Eight edge grips and the move puck, shown on a settled
+    /// selection so a restored region reads as adjustable rather than
+    /// as a picture of where the last one was.
+    grips: [gtk::Box; 8],
+    puck: gtk::Box,
     /// The overlay's size in logical pixels, learned once it maps.
     size: (i32, i32),
     /// Image pixels per logical pixel, learned at draw time — the
@@ -186,8 +197,31 @@ fn build_overlay(
     readout.append(&readout_label);
     readout.set_visible(false);
 
+    let grips: [gtk::Box; 8] = std::array::from_fn(|_| {
+        let grip = gtk::Box::new(gtk::Orientation::Horizontal, 0);
+        grip.add_css_class("capture-grip");
+        grip.set_size_request(GRIP, GRIP);
+        grip.set_visible(false);
+        grip
+    });
+    let puck = gtk::Box::new(gtk::Orientation::Horizontal, 0);
+    puck.add_css_class("capture-puck");
+    puck.set_size_request(PUCK, PUCK);
+    puck.set_visible(false);
+    {
+        // A plus, the way every move affordance draws one. A label
+        // rather than two nested bars: the glyph is in every font and
+        // needs no layout of its own.
+        let cross = gtk::Label::new(Some("+"));
+        cross.set_hexpand(true);
+        cross.set_vexpand(true);
+        puck.append(&cross);
+    }
+
     let state = Rc::new(RefCell::new(State {
         frozen: frozen.clone(),
+        grips: grips.clone(),
+        puck: puck.clone(),
         readout: readout.clone(),
         readout_label: readout_label.clone(),
         fixed: fixed.clone(),
@@ -243,6 +277,10 @@ fn build_overlay(
         fixed.put(guide, 0.0, 0.0);
     }
     fixed.put(&readout, 0.0, 0.0);
+    for grip in &grips {
+        fixed.put(grip, 0.0, 0.0);
+    }
+    fixed.put(&puck, 0.0, 0.0);
     overlay.add_overlay(&fixed);
     // The cursor goes on the widget the pointer is actually over, not
     // the window: GTK resolves it from the widget under the pointer
@@ -330,6 +368,7 @@ fn layout_shade(state: &State) {
         }
         state.outline.set_visible(false);
         state.readout.set_visible(false);
+        hide_grips(state);
         layout_crosshair(state, true);
         return;
     };
@@ -356,6 +395,7 @@ fn layout_shade(state: &State) {
     } else {
         state.readout.set_visible(false);
     }
+    layout_grips(state, rect);
     // Once there is a rectangle, it is the thing being aimed — the
     // guides would just be two more lines over it.
     layout_crosshair(state, false);
@@ -369,6 +409,58 @@ fn apply_cursor(widget: &gtk::Fixed, mode: Mode) {
         Mode::Area => "crosshair",
         Mode::Window => "pointer",
     }));
+}
+
+/// Put the eight grips on the selection's edges and the puck at its
+/// middle, or hide them.
+///
+/// Only on a settled selection: during a drag the rectangle is already
+/// following the pointer, and eight squares chasing it would be
+/// noise. Their positions are the same ones `hit_test_handle` answers
+/// for, so a grip is exactly where the grab is.
+fn layout_grips(state: &State, rect: Rect) {
+    if state.dragging || rect.width < 1 || rect.height < 1 {
+        hide_grips(state);
+        return;
+    }
+    let (x, y, w, h) = (
+        rect.x as f64,
+        rect.y as f64,
+        rect.width as f64,
+        rect.height as f64,
+    );
+    let half = GRIP as f64 / 2.0;
+    let spots = [
+        (x, y),
+        (x + w / 2.0, y),
+        (x + w, y),
+        (x + w, y + h / 2.0),
+        (x + w, y + h),
+        (x + w / 2.0, y + h),
+        (x, y + h),
+        (x, y + h / 2.0),
+    ];
+    for (grip, (cx, cy)) in state.grips.iter().zip(spots) {
+        state.fixed.move_(grip, cx - half, cy - half);
+        grip.set_visible(true);
+    }
+
+    // The puck needs room of its own — on a small region it would
+    // cover the thing being framed.
+    let puck_fits = w > PUCK as f64 * 2.0 && h > PUCK as f64 * 2.0;
+    state.fixed.move_(
+        &state.puck,
+        x + w / 2.0 - PUCK as f64 / 2.0,
+        y + h / 2.0 - PUCK as f64 / 2.0,
+    );
+    state.puck.set_visible(puck_fits);
+}
+
+fn hide_grips(state: &State) {
+    for grip in &state.grips {
+        grip.set_visible(false);
+    }
+    state.puck.set_visible(false);
 }
 
 /// Show the selection's pixel size beside the corner being dragged.
@@ -730,6 +822,20 @@ fn install_css(app: &gtk::Application) {
             cairo blends on every motion event. */
          .capture-shade { background: rgba(0, 0, 0, 0.45); }
          .capture-readout { padding: 4px 10px; }
+         /* Grips and puck: the scrolling capture's white-on-dark, so a
+            selection looks the same in either overlay. */
+         .capture-grip {
+             background: rgba(255, 255, 255, 0.92);
+             border-radius: 3px;
+             box-shadow: 0 1px 3px rgba(0, 0, 0, 0.5);
+         }
+         .capture-puck {
+             background: rgba(20, 20, 26, 0.84);
+             border: 2px solid rgba(255, 255, 255, 0.92);
+             border-radius: 999px;
+             color: rgba(255, 255, 255, 0.92);
+             font-size: 17px;
+         }
          .region-capture-outline {
              border: 1px solid rgba(255, 255, 255, 0.9);
          }

--- a/src/region_capture.rs
+++ b/src/region_capture.rs
@@ -28,7 +28,7 @@ use std::cell::RefCell;
 use std::rc::Rc;
 
 use crate::capture::Rect;
-use crate::scroll_capture::{ResizeHandle, Selection, hit_test_handle};
+use crate::scroll_capture::{ResizeHandle, Selection, handle_cursor_name, hit_test_handle};
 use crate::windows::{WindowTarget, visible_windows, window_at};
 
 /// Gap between the hint pill and the bottom of the screen. Matches the
@@ -571,6 +571,7 @@ fn install_pointer(
     let motion = gtk::EventControllerMotion::new();
     {
         let state = Rc::clone(state);
+        let surface_w = surface.clone();
         motion.connect_motion(move |_, x, y| {
             let mut state = state.borrow_mut();
             state.pointer = (x, y);
@@ -579,6 +580,17 @@ fn install_pointer(
                 if hit != state.hovered {
                     state.hovered = hit;
                 }
+            }
+            // Over a settled selection, the cursor says what a drag
+            // would do to it — resize from an edge, move from the
+            // middle — rather than offering a crosshair that would
+            // start a new rectangle.
+            if state.mode == Mode::Area
+                && !state.dragging
+                && let Some(rect) = state.selection
+            {
+                let handle = hit_test_handle(selection_of(rect), x, y);
+                surface_w.set_cursor_from_name(Some(handle_cursor_name(handle, "crosshair")));
             }
             layout_shade(&state);
         });

--- a/src/region_capture.rs
+++ b/src/region_capture.rs
@@ -224,9 +224,12 @@ fn build_overlay(
 
     let hint = gtk::Label::new(Some(Mode::Area.hint()));
     hint.add_css_class("region-capture-hint");
+    // Centred on screen, like the scrolling capture's prompt: the
+    // instructions are the only thing to read before a drag starts, so
+    // they belong where the eye already is rather than in a corner it
+    // has to find.
     hint.set_halign(gtk::Align::Center);
-    hint.set_valign(gtk::Align::End);
-    hint.set_margin_bottom(48);
+    hint.set_valign(gtk::Align::Center);
     overlay.add_overlay(&hint);
     window.set_child(Some(&overlay));
 

--- a/src/region_capture.rs
+++ b/src/region_capture.rs
@@ -149,7 +149,7 @@ fn build_overlay(
     // longer where it was drawn.
     let shade = std::array::from_fn(|_| {
         let strip = gtk::Box::new(gtk::Orientation::Horizontal, 0);
-        strip.add_css_class("region-capture-shade");
+        strip.add_css_class("capture-shade");
         strip
     });
     let outline = gtk::Box::new(gtk::Orientation::Horizontal, 0);
@@ -543,7 +543,7 @@ fn install_css(app: &gtk::Application) {
         ".region-capture-overlay { background: transparent; }
          /* The dim sheet, as strips GTK composites rather than pixels
             cairo blends on every motion event. */
-         .region-capture-shade { background: rgba(0, 0, 0, 0.45); }
+         .capture-shade { background: rgba(0, 0, 0, 0.45); }
          .region-capture-outline {
              border: 1px solid rgba(255, 255, 255, 0.9);
          }

--- a/src/region_capture.rs
+++ b/src/region_capture.rs
@@ -30,6 +30,10 @@ use std::rc::Rc;
 use crate::capture::Rect;
 use crate::windows::{WindowTarget, visible_windows, window_at};
 
+/// Gap between the hint pill and the bottom of the screen. Matches the
+/// scrolling capture's prompt, which sits at the same height.
+const HINT_MARGIN_BOTTOM: i32 = 48;
+
 /// Ignore drags this small: a click that wobbles by a pixel is a click,
 /// and capturing a 3×2 region helps nobody.
 const MIN_DRAG: f64 = 8.0;
@@ -250,8 +254,12 @@ fn build_overlay(
     // instructions are the only thing to read before a drag starts, so
     // they belong where the eye already is rather than in a corner it
     // has to find.
+    // Along the bottom: the instructions are read once and then they
+    // are in the way, and the middle of the screen is exactly where
+    // the aiming happens.
     hint_pill.set_halign(gtk::Align::Center);
-    hint_pill.set_valign(gtk::Align::Center);
+    hint_pill.set_valign(gtk::Align::End);
+    hint_pill.set_margin_bottom(HINT_MARGIN_BOTTOM);
     overlay.add_overlay(&hint_pill);
     window.set_child(Some(&overlay));
 

--- a/src/region_capture.rs
+++ b/src/region_capture.rs
@@ -212,6 +212,9 @@ fn build_overlay(
     readout.set_focus_on_click(false);
     readout.set_tooltip_text(Some("Capture this region"));
     readout.set_visible(false);
+    // Its own pointer, or it inherits the surface's crosshair and
+    // reads as somewhere to start a new drag rather than a button.
+    readout.set_cursor_from_name(Some("pointer"));
     {
         let faces = readout_faces.clone();
         let hover = gtk::EventControllerMotion::new();
@@ -234,6 +237,7 @@ fn build_overlay(
     let puck = gtk::DrawingArea::new();
     puck.set_size_request(PUCK, PUCK);
     puck.set_visible(false);
+    puck.set_cursor_from_name(Some("move"));
     puck.set_draw_func(|_, ctx, w, h| {
         let r = (w.min(h) as f64 / 2.0 - 1.0).max(1.0);
         crate::scroll_capture::draw_move_puck(ctx, w as f64 / 2.0, h as f64 / 2.0, r);

--- a/src/region_capture.rs
+++ b/src/region_capture.rs
@@ -463,18 +463,21 @@ fn hide_grips(state: &State) {
     state.puck.set_visible(false);
 }
 
-/// Show the selection's pixel size beside the corner being dragged.
+/// Show the selection's size beside the corner being dragged.
+///
+/// In the overlay's own logical pixels, not the capture's device ones.
+/// The editor reports the same way — it divides the image by the
+/// capture scale so a region framed on a 2x display reads at the size
+/// it looked, not double — and a capture tool whose two halves
+/// disagree about how big the shot is teaches nobody anything.
 fn layout_readout(state: &State, rect: Rect) {
-    // The capture's pixels, not the overlay's: the number should match
-    // the file, and on a 2x display those differ by half.
-    let scaled = to_image_rect(rect, state.image_scale, &state.frozen);
-    if scaled.width < 1 || scaled.height < 1 {
+    if rect.width < 1 || rect.height < 1 {
         state.readout.set_visible(false);
         return;
     }
     state
         .readout_label
-        .set_text(&format!("{} × {}", scaled.width, scaled.height));
+        .set_text(&format!("{} × {}", rect.width, rect.height));
     state.readout.set_visible(true);
 
     let (_, width, _, _) = state.readout.measure(gtk::Orientation::Horizontal, -1);

--- a/src/region_capture.rs
+++ b/src/region_capture.rs
@@ -99,6 +99,10 @@ struct State {
     crosshair: [gtk::Box; 2],
     /// Where the pointer is, in logical pixels.
     pointer: (f64, f64),
+    /// Live pixel size of the selection, in the capture's own pixels —
+    /// what the saved file will measure, not what the overlay shows.
+    readout: gtk::Box,
+    readout_label: gtk::Label,
     /// The overlay's size in logical pixels, learned once it maps.
     size: (i32, i32),
     /// Image pixels per logical pixel, learned at draw time — the
@@ -164,8 +168,18 @@ fn build_overlay(
     });
 
     let fixed = gtk::Fixed::new();
+    let readout_label = gtk::Label::new(None);
+    readout_label.add_css_class("scroll-capture-prompt-label");
+    let readout = gtk::Box::new(gtk::Orientation::Horizontal, 0);
+    readout.add_css_class("scroll-capture-pill");
+    readout.add_css_class("capture-readout");
+    readout.append(&readout_label);
+    readout.set_visible(false);
+
     let state = Rc::new(RefCell::new(State {
         frozen: frozen.clone(),
+        readout: readout.clone(),
+        readout_label: readout_label.clone(),
         fixed: fixed.clone(),
         shade: shade.clone(),
         outline: outline.clone(),
@@ -216,6 +230,7 @@ fn build_overlay(
     for guide in &crosshair {
         fixed.put(guide, 0.0, 0.0);
     }
+    fixed.put(&readout, 0.0, 0.0);
     overlay.add_overlay(&fixed);
     // The cursor goes on the widget the pointer is actually over, not
     // the window: GTK resolves it from the widget under the pointer
@@ -298,6 +313,7 @@ fn layout_shade(state: &State) {
             place(index, 0.0, 0.0, 0.0, 0.0);
         }
         state.outline.set_visible(false);
+        state.readout.set_visible(false);
         layout_crosshair(state, true);
         return;
     };
@@ -316,6 +332,7 @@ fn layout_shade(state: &State) {
     state.outline.set_size_request(w as i32, h as i32);
     state.fixed.move_(&state.outline, x, y);
     state.outline.set_visible(w >= 1.0 && h >= 1.0);
+    layout_readout(state, rect);
     // Once there is a rectangle, it is the thing being aimed — the
     // guides would just be two more lines over it.
     layout_crosshair(state, false);
@@ -329,6 +346,35 @@ fn apply_cursor(widget: &gtk::Fixed, mode: Mode) {
         Mode::Area => "crosshair",
         Mode::Window => "pointer",
     }));
+}
+
+/// Show the selection's pixel size beside the corner being dragged.
+fn layout_readout(state: &State, rect: Rect) {
+    // The capture's pixels, not the overlay's: the number should match
+    // the file, and on a 2x display those differ by half.
+    let scaled = to_image_rect(rect, state.image_scale, &state.frozen);
+    if scaled.width < 1 || scaled.height < 1 {
+        state.readout.set_visible(false);
+        return;
+    }
+    state
+        .readout_label
+        .set_text(&format!("{} × {}", scaled.width, scaled.height));
+    state.readout.set_visible(true);
+
+    let (_, width, _, _) = state.readout.measure(gtk::Orientation::Horizontal, -1);
+    let (_, height, _, _) = state
+        .readout
+        .measure(gtk::Orientation::Vertical, width);
+    let corner = state.pointer;
+    let origin = state.origin;
+    let (x, y) = readout_position(
+        origin,
+        corner,
+        (width as f64, height as f64),
+        (state.size.0 as f64, state.size.1 as f64),
+    );
+    state.fixed.move_(&state.readout, x, y);
 }
 
 /// Put the guides through the pointer, or hide them.
@@ -513,6 +559,36 @@ fn install_keys(
     window.add_controller(keys);
 }
 
+/// Where the size readout goes for a selection dragged from `origin`
+/// to `corner`, given the readout's own size and the screen's.
+///
+/// It follows the moving corner and sits on the *outside* of it — the
+/// direction of the drag says which side that is, so the label never
+/// covers the pixels being measured. Clamped to the screen, because
+/// the moving corner is exactly what you drag off the edge.
+pub fn readout_position(
+    origin: (f64, f64),
+    corner: (f64, f64),
+    readout: (f64, f64),
+    screen: (f64, f64),
+) -> (f64, f64) {
+    const GAP: f64 = 12.0;
+    let x = if corner.0 >= origin.0 {
+        corner.0 + GAP
+    } else {
+        corner.0 - GAP - readout.0
+    };
+    let y = if corner.1 >= origin.1 {
+        corner.1 + GAP
+    } else {
+        corner.1 - GAP - readout.1
+    };
+    (
+        x.clamp(0.0, (screen.0 - readout.0).max(0.0)),
+        y.clamp(0.0, (screen.1 - readout.1).max(0.0)),
+    )
+}
+
 /// Normalise two corners into a rectangle, whichever way it was dragged.
 fn rect_between(a: (f64, f64), b: (f64, f64)) -> Rect {
     let x = a.0.min(b.0);
@@ -544,6 +620,7 @@ fn install_css(app: &gtk::Application) {
          /* The dim sheet, as strips GTK composites rather than pixels
             cairo blends on every motion event. */
          .capture-shade { background: rgba(0, 0, 0, 0.45); }
+         .capture-readout { padding: 4px 10px; }
          .region-capture-outline {
              border: 1px solid rgba(255, 255, 255, 0.9);
          }
@@ -580,7 +657,7 @@ fn install_css(app: &gtk::Application) {
 
 #[cfg(test)]
 mod tests {
-    use super::{MIN_DRAG, Mode, Rect, rect_between, to_image_rect};
+    use super::{MIN_DRAG, Mode, Rect, readout_position, rect_between, to_image_rect};
     use relm4::gtk::gdk_pixbuf::{Colorspace, Pixbuf};
 
     /// Dragging up-left has to produce the same rectangle as dragging
@@ -612,6 +689,32 @@ mod tests {
     /// A 2x display hands back a capture twice the overlay's logical
     /// size, and a selection that ignored that would crop a quarter of
     /// what was outlined.
+    /// The readout follows the corner being dragged and sits outside
+    /// it, so it never covers the pixels it is measuring.
+    #[test]
+    fn the_readout_sits_outside_the_moving_corner() {
+        let screen = (2000.0, 1200.0);
+        let size = (90.0, 30.0);
+        // Dragging down-right: below and right of the corner.
+        let (x, y) = readout_position((100.0, 100.0), (500.0, 400.0), size, screen);
+        assert!(x > 500.0 && y > 400.0);
+        // Dragging up-left: above and left, clear of the corner.
+        let (x, y) = readout_position((500.0, 400.0), (100.0, 100.0), size, screen);
+        assert!(x + size.0 < 100.0 && y + size.1 < 100.0);
+    }
+
+    /// The corner you drag is the one you drag off the screen, so the
+    /// readout has to stay on it.
+    #[test]
+    fn the_readout_stays_on_screen() {
+        let screen = (2000.0, 1200.0);
+        let size = (90.0, 30.0);
+        let (x, y) = readout_position((100.0, 100.0), (1999.0, 1199.0), size, screen);
+        assert!(x + size.0 <= screen.0 && y + size.1 <= screen.1);
+        let (x, y) = readout_position((500.0, 400.0), (0.0, 0.0), size, screen);
+        assert!(x >= 0.0 && y >= 0.0);
+    }
+
     #[test]
     fn a_selection_converts_into_the_captures_own_pixels() {
         let frozen = Pixbuf::new(Colorspace::Rgb, true, 8, 6144, 3456).unwrap();

--- a/src/region_capture.rs
+++ b/src/region_capture.rs
@@ -48,7 +48,6 @@ const PUCK_GAP: f64 = 10.0;
 /// and capturing a 3×2 region helps nobody.
 const MIN_DRAG: f64 = 8.0;
 
-
 /// What the user chose.
 ///
 /// Rectangles are in the captured image's own pixels, not the
@@ -166,11 +165,7 @@ pub fn run(frozen: Pixbuf) -> Result<RegionOutcome> {
     Ok(shared.borrow().clone())
 }
 
-fn build_overlay(
-    app: &gtk::Application,
-    shared: &Rc<RefCell<RegionOutcome>>,
-    frozen: Pixbuf,
-) {
+fn build_overlay(app: &gtk::Application, shared: &Rc<RefCell<RegionOutcome>>, frozen: Pixbuf) {
     // Windows are read once, at the moment the overlay goes up. The
     // screen is frozen behind it from the user's point of view, so a
     // list that shifted underneath would snap to something that is no
@@ -540,7 +535,6 @@ fn hide_grips(state: &State) {
     state.puck.set_visible(false);
 }
 
-
 /// Show the selection's size beside the corner being dragged.
 ///
 /// In the overlay's own logical pixels, not the capture's device ones.
@@ -559,9 +553,7 @@ fn layout_readout(state: &State, rect: Rect) {
     state.readout.set_visible(true);
 
     let (_, width, _, _) = state.readout.measure(gtk::Orientation::Horizontal, -1);
-    let (_, height, _, _) = state
-        .readout
-        .measure(gtk::Orientation::Vertical, width);
+    let (_, height, _, _) = state.readout.measure(gtk::Orientation::Vertical, width);
     let corner = state.pointer;
     let origin = state.origin;
     let (x, y) = readout_position(
@@ -689,7 +681,9 @@ fn install_pointer(
                 .map(selection_of)
                 .and_then(|sel| hit_test_handle(sel, x, y));
             match state.resize_handle {
-                Some(_) => state.resize_anchor = state.selection.map(selection_of).unwrap_or_default(),
+                Some(_) => {
+                    state.resize_anchor = state.selection.map(selection_of).unwrap_or_default()
+                }
                 None => state.selection = None,
             }
         });
@@ -704,12 +698,9 @@ fn install_pointer(
             let origin = state.origin;
             state.pointer = (origin.0 + dx, origin.1 + dy);
             state.selection = Some(match state.resize_handle {
-                Some(handle) => rect_of(handle.apply(
-                    state.resize_anchor,
-                    origin,
-                    origin.0 + dx,
-                    origin.1 + dy,
-                )),
+                Some(handle) => {
+                    rect_of(handle.apply(state.resize_anchor, origin, origin.0 + dx, origin.1 + dy))
+                }
                 None => rect_between(origin, (origin.0 + dx, origin.1 + dy)),
             });
             layout_shade(&state);

--- a/src/region_capture.rs
+++ b/src/region_capture.rs
@@ -115,17 +115,13 @@ struct State {
     pointer: (f64, f64),
     /// Live pixel size of the selection, in the capture's own pixels —
     /// what the saved file will measure, not what the overlay shows.
-    readout: gtk::Box,
+    readout: gtk::Button,
     readout_label: gtk::Label,
     /// Eight edge grips and the move puck, shown on a settled
     /// selection so a restored region reads as adjustable rather than
     /// as a picture of where the last one was.
     grips: [gtk::Box; 8],
-    puck: gtk::Box,
-    /// Take-the-shot button, beside the puck. A restored region is
-    /// framed and waiting; the keyboard says Enter, and this says the
-    /// same thing to a hand already on the mouse.
-    shutter: gtk::Button,
+    puck: gtk::DrawingArea,
     /// The overlay's size in logical pixels, learned once it maps.
     size: (i32, i32),
     /// Image pixels per logical pixel, learned at draw time — the
@@ -196,13 +192,34 @@ fn build_overlay(
     });
 
     let fixed = gtk::Fixed::new();
+    // The size pill IS the shutter: it already sits under the region
+    // saying how big the shot is, and "take it" is the only thing
+    // anyone wants to do next. Hovering swaps the number for a camera
+    // so the click is advertised before it is made.
     let readout_label = gtk::Label::new(None);
     readout_label.add_css_class("scroll-capture-prompt-label");
-    let readout = gtk::Box::new(gtk::Orientation::Horizontal, 0);
+    let readout_camera = gtk::Image::from_icon_name("camera-regular");
+    let readout_faces = gtk::Stack::new();
+    readout_faces.add_named(&readout_label, Some("size"));
+    readout_faces.add_named(&readout_camera, Some("camera"));
+    readout_faces.set_visible_child_name("size");
+
+    let readout = gtk::Button::new();
+    readout.set_child(Some(&readout_faces));
     readout.add_css_class("scroll-capture-pill");
     readout.add_css_class("capture-readout");
-    readout.append(&readout_label);
+    readout.set_focusable(false);
+    readout.set_focus_on_click(false);
+    readout.set_tooltip_text(Some("Capture this region"));
     readout.set_visible(false);
+    {
+        let faces = readout_faces.clone();
+        let hover = gtk::EventControllerMotion::new();
+        let faces_leave = faces.clone();
+        hover.connect_enter(move |_, _, _| faces.set_visible_child_name("camera"));
+        hover.connect_leave(move |_| faces_leave.set_visible_child_name("size"));
+        readout.add_controller(hover);
+    }
 
     let grips: [gtk::Box; 8] = std::array::from_fn(|_| {
         let grip = gtk::Box::new(gtk::Orientation::Horizontal, 0);
@@ -211,33 +228,21 @@ fn build_overlay(
         grip.set_visible(false);
         grip
     });
-    let puck = gtk::Box::new(gtk::Orientation::Horizontal, 0);
-    puck.add_css_class("capture-puck");
+    // The scrolling capture's puck, drawn by the same code rather than
+    // approximated with a glyph: it is one control and should look
+    // like one. A DrawingArea this small repaints for nothing.
+    let puck = gtk::DrawingArea::new();
     puck.set_size_request(PUCK, PUCK);
     puck.set_visible(false);
-    {
-        // A plus, the way every move affordance draws one. A label
-        // rather than two nested bars: the glyph is in every font and
-        // needs no layout of its own.
-        let cross = gtk::Label::new(Some("+"));
-        cross.set_hexpand(true);
-        cross.set_vexpand(true);
-        puck.append(&cross);
-    }
-
-    let shutter = gtk::Button::from_icon_name("camera-regular");
-    shutter.add_css_class("capture-shutter");
-    shutter.set_focusable(false);
-    shutter.set_focus_on_click(false);
-    shutter.set_tooltip_text(Some("Capture this region"));
-    shutter.set_size_request(PUCK, PUCK);
-    shutter.set_visible(false);
+    puck.set_draw_func(|_, ctx, w, h| {
+        let r = (w.min(h) as f64 / 2.0 - 1.0).max(1.0);
+        crate::scroll_capture::draw_move_puck(ctx, w as f64 / 2.0, h as f64 / 2.0, r);
+    });
 
     let state = Rc::new(RefCell::new(State {
         frozen: frozen.clone(),
         grips: grips.clone(),
         puck: puck.clone(),
-        shutter: shutter.clone(),
         readout: readout.clone(),
         readout_label: readout_label.clone(),
         fixed: fixed.clone(),
@@ -297,7 +302,6 @@ fn build_overlay(
         fixed.put(grip, 0.0, 0.0);
     }
     fixed.put(&puck, 0.0, 0.0);
-    fixed.put(&shutter, 0.0, 0.0);
     overlay.add_overlay(&fixed);
     {
         // Commits exactly what Enter would, through the same path, so
@@ -305,7 +309,7 @@ fn build_overlay(
         let state_for_shutter = Rc::clone(&state);
         let shared_for_shutter = Rc::clone(shared);
         let window_for_shutter = window.clone();
-        shutter.connect_clicked(move |_| {
+        readout.connect_clicked(move |_| {
             let choice = committed_region(&state_for_shutter.borrow());
             if let Some(choice) = choice {
                 *shared_for_shutter.borrow_mut() = choice;
@@ -508,17 +512,13 @@ fn layout_grips(state: &State, rect: Rect) {
         .set_text(&format!("{} × {}", rect.width, rect.height));
     let (_, pill_w, _, _) = state.readout.measure(gtk::Orientation::Horizontal, -1);
     let (_, pill_h, _, _) = state.readout.measure(gtk::Orientation::Vertical, pill_w);
-    let row_w = pill_w as f64 + PUCK_GAP + PUCK as f64;
-    let row_x = centre_x - row_w / 2.0;
     let row_y = puck_top + PUCK as f64 + PUCK_GAP;
     let row_fits = fits && h > PUCK as f64 * 2.0 + pill_h as f64 + PUCK_GAP;
 
-    state.fixed.move_(&state.readout, row_x, row_y);
-    state.readout.set_visible(row_fits);
     state
         .fixed
-        .move_(&state.shutter, row_x + pill_w as f64 + PUCK_GAP, row_y);
-    state.shutter.set_visible(row_fits);
+        .move_(&state.readout, centre_x - pill_w as f64 / 2.0, row_y);
+    state.readout.set_visible(row_fits);
 }
 
 fn hide_grips(state: &State) {
@@ -526,7 +526,6 @@ fn hide_grips(state: &State) {
         grip.set_visible(false);
     }
     state.puck.set_visible(false);
-    state.shutter.set_visible(false);
 }
 
 
@@ -903,7 +902,6 @@ fn install_css(app: &gtk::Application) {
          /* The dim sheet, as strips GTK composites rather than pixels
             cairo blends on every motion event. */
          .capture-shade { background: rgba(0, 0, 0, 0.45); }
-         .capture-readout { padding: 4px 10px; }
          /* Grips and puck: the scrolling capture's white-on-dark, so a
             selection looks the same in either overlay. */
          .capture-grip {
@@ -911,24 +909,14 @@ fn install_css(app: &gtk::Application) {
              border-radius: 3px;
              box-shadow: 0 1px 3px rgba(0, 0, 0, 0.5);
          }
-         .capture-shutter {
-             background: rgba(20, 20, 26, 0.84);
-             border: 2px solid rgba(255, 255, 255, 0.92);
-             border-radius: 999px;
-             color: rgba(255, 255, 255, 0.92);
+         .capture-readout {
+             color: rgba(245, 245, 247, 0.92);
+             padding: 4px 12px;
              min-height: 0;
              min-width: 0;
-             padding: 0;
          }
-         .capture-shutter:hover {
-             background: rgba(60, 60, 70, 0.92);
-         }
-         .capture-puck {
-             background: rgba(20, 20, 26, 0.84);
-             border: 2px solid rgba(255, 255, 255, 0.92);
-             border-radius: 999px;
-             color: rgba(255, 255, 255, 0.92);
-             font-size: 17px;
+         .capture-readout:hover {
+             background-color: rgba(60, 60, 70, 0.94);
          }
          .region-capture-outline {
              border: 1px solid rgba(255, 255, 255, 0.9);

--- a/src/region_capture.rs
+++ b/src/region_capture.rs
@@ -28,6 +28,7 @@ use std::cell::RefCell;
 use std::rc::Rc;
 
 use crate::capture::Rect;
+use crate::scroll_capture::{ResizeHandle, Selection, hit_test_handle};
 use crate::windows::{WindowTarget, visible_windows, window_at};
 
 /// Gap between the hint pill and the bottom of the screen. Matches the
@@ -120,6 +121,11 @@ struct State {
     /// The rectangle being dragged, or the last one dragged.
     selection: Option<Rect>,
     dragging: bool,
+    /// The handle a drag grabbed, when it started on the edge of an
+    /// existing selection — a restored region is meant to be adjusted,
+    /// not replaced by whatever you drag next.
+    resize_handle: Option<ResizeHandle>,
+    resize_anchor: Selection,
     windows: Vec<WindowTarget>,
     /// The window under the pointer while in window mode.
     hovered: Option<WindowTarget>,
@@ -195,6 +201,8 @@ fn build_overlay(
         origin: (0.0, 0.0),
         selection: None,
         dragging: false,
+        resize_handle: None,
+        resize_anchor: Selection::default(),
         windows: visible_windows(),
         hovered: None,
     }));
@@ -340,7 +348,14 @@ fn layout_shade(state: &State) {
     state.outline.set_size_request(w as i32, h as i32);
     state.fixed.move_(&state.outline, x, y);
     state.outline.set_visible(w >= 1.0 && h >= 1.0);
-    layout_readout(state, rect);
+    // Only while a drag is in flight: a restored region is a framing,
+    // not a measurement, and the pill would sit over the picture
+    // announcing a number nobody asked for.
+    if state.dragging {
+        layout_readout(state, rect);
+    } else {
+        state.readout.set_visible(false);
+    }
     // Once there is a rectangle, it is the thing being aimed — the
     // guides would just be two more lines over it.
     layout_crosshair(state, false);
@@ -482,7 +497,16 @@ fn install_pointer(
             let mut state = state.borrow_mut();
             state.origin = (x, y);
             state.dragging = true;
-            state.selection = None;
+            // Starting on the edge of the current selection adjusts
+            // it; starting anywhere else replaces it.
+            state.resize_handle = state
+                .selection
+                .map(selection_of)
+                .and_then(|sel| hit_test_handle(sel, x, y));
+            match state.resize_handle {
+                Some(_) => state.resize_anchor = state.selection.map(selection_of).unwrap_or_default(),
+                None => state.selection = None,
+            }
         });
     }
     {
@@ -493,7 +517,16 @@ fn install_pointer(
                 return;
             }
             let origin = state.origin;
-            state.selection = Some(rect_between(origin, (origin.0 + dx, origin.1 + dy)));
+            state.pointer = (origin.0 + dx, origin.1 + dy);
+            state.selection = Some(match state.resize_handle {
+                Some(handle) => rect_of(handle.apply(
+                    state.resize_anchor,
+                    origin,
+                    origin.0 + dx,
+                    origin.1 + dy,
+                )),
+                None => rect_between(origin, (origin.0 + dx, origin.1 + dy)),
+            });
             layout_shade(&state);
         });
     }
@@ -505,6 +538,14 @@ fn install_pointer(
             let choice = {
                 let mut state = state.borrow_mut();
                 state.dragging = false;
+                let resized = state.resize_handle.take().is_some();
+                // A resize adjusts the rectangle; it doesn't commit it.
+                // Otherwise nudging a restored region by a pixel would
+                // fire the capture before it was right.
+                if resized {
+                    layout_shade(&state);
+                    return;
+                }
                 match state.mode {
                     // A click in window mode takes what it points at.
                     Mode::Window => committed_region(&state),
@@ -579,6 +620,7 @@ fn install_keys(
                 state.pointer = (x + w, y + h);
                 hint.set_text(state.mode.hint());
                 layout_shade(&state);
+                apply_cursor(&cursor_target, Mode::Area);
                 gtk::glib::Propagation::Stop
             }
             gdk::Key::space => {
@@ -633,6 +675,27 @@ pub fn readout_position(
         x.clamp(0.0, (screen.0 - readout.0).max(0.0)),
         y.clamp(0.0, (screen.1 - readout.1).max(0.0)),
     )
+}
+
+/// The scroll overlay's `Selection` for a `Rect`, and back. The two
+/// overlays measure the same thing in the same units; only the type
+/// differs, and the resize maths lives on `Selection`.
+fn selection_of(rect: Rect) -> Selection {
+    Selection {
+        x: rect.x as f64,
+        y: rect.y as f64,
+        w: rect.width as f64,
+        h: rect.height as f64,
+    }
+}
+
+fn rect_of(sel: Selection) -> Rect {
+    Rect {
+        x: sel.x.round() as i32,
+        y: sel.y.round() as i32,
+        width: sel.w.round() as i32,
+        height: sel.h.round() as i32,
+    }
 }
 
 /// Normalise two corners into a rectangle, whichever way it was dragged.

--- a/src/scroll_capture/mod.rs
+++ b/src/scroll_capture/mod.rs
@@ -195,6 +195,23 @@ fn pointer_over_selected_page(sel: Selection, x: f64, y: f64) -> bool {
     inside && hit_test_handle(sel, x, y).is_none()
 }
 
+/// The pointer shape for a grab on `handle`, or `fallback` where
+/// there is nothing to grab. Shared with the area capture: a
+/// selection that can be resized should say so the same way in both.
+pub(crate) fn handle_cursor_name(
+    handle: Option<ResizeHandle>,
+    fallback: &'static str,
+) -> &'static str {
+    match handle {
+        Some(ResizeHandle::TopLeft) | Some(ResizeHandle::BottomRight) => "nwse-resize",
+        Some(ResizeHandle::TopRight) | Some(ResizeHandle::BottomLeft) => "nesw-resize",
+        Some(ResizeHandle::Top) | Some(ResizeHandle::Bottom) => "ns-resize",
+        Some(ResizeHandle::Left) | Some(ResizeHandle::Right) => "ew-resize",
+        Some(ResizeHandle::Move) => "move",
+        None => fallback,
+    }
+}
+
 pub(crate) fn hit_test_handle(sel: Selection, x: f64, y: f64) -> Option<ResizeHandle> {
     // 1) Corners win if you're near one (so you get diagonal resize even
     // though the edge bands overlap there).
@@ -1206,14 +1223,7 @@ fn build_overlay(
             }
             update_selected_keyboard_zone(&state, &window_w, x, y);
             let sel = state.borrow().selection;
-            let name = match hit_test_handle(sel, x, y) {
-                Some(ResizeHandle::TopLeft) | Some(ResizeHandle::BottomRight) => "nwse-resize",
-                Some(ResizeHandle::TopRight) | Some(ResizeHandle::BottomLeft) => "nesw-resize",
-                Some(ResizeHandle::Top) | Some(ResizeHandle::Bottom) => "ns-resize",
-                Some(ResizeHandle::Left) | Some(ResizeHandle::Right) => "ew-resize",
-                Some(ResizeHandle::Move) => "move",
-                None => "default",
-            };
+            let name = handle_cursor_name(hit_test_handle(sel, x, y), "default");
             drawing_w.set_cursor_from_name(Some(name));
         });
     }

--- a/src/scroll_capture/mod.rs
+++ b/src/scroll_capture/mod.rs
@@ -4222,7 +4222,15 @@ fn draw_handles(cr: &cairo::Context, sel: Selection) {
 
     // Move handle: filled circle with a 4-way arrow glyph at the center.
     let (cx, cy) = ResizeHandle::Move.center(sel);
-    let r = MOVE_HANDLE_RADIUS;
+    draw_move_puck(cr, cx, cy, MOVE_HANDLE_RADIUS);
+}
+
+/// The move puck: a dark disc with a white ring and a four-way arrow.
+///
+/// Shared with the area capture, which draws it into a small widget of
+/// its own — the same control should look the same in both overlays,
+/// and this is a glyph rather than a shape a stylesheet can describe.
+pub(crate) fn draw_move_puck(cr: &cairo::Context, cx: f64, cy: f64, r: f64) {
     cr.arc(cx, cy, r, 0.0, std::f64::consts::TAU);
     cr.set_source_rgba(0.0, 0.0, 0.0, 0.6);
     let _ = cr.fill_preserve();

--- a/src/scroll_capture/mod.rs
+++ b/src/scroll_capture/mod.rs
@@ -1027,12 +1027,6 @@ fn build_overlay(
         let crosshair_drag = crosshair.clone();
         let readout_a = readout.clone();
         let readout_label_a = readout_label.clone();
-        // Read once: the monitor's scale can't change under a drag,
-        // and finding it costs a subprocess.
-        let readout_scale = crate::display::hyprland_focused_monitor()
-            .map(|m| m.scale as f64)
-            .unwrap_or(1.0)
-            .max(0.0001);
         drag.connect_drag_update(move |_, dx, dy| {
             let mut s = state.borrow_mut();
             if !s.drag_active {
@@ -1069,7 +1063,6 @@ fn build_overlay(
                         selection,
                         origin,
                         (ox + dx, oy + dy),
-                        readout_scale,
                     );
                     drawing_w.queue_draw();
                     return;
@@ -1107,7 +1100,6 @@ fn build_overlay(
                 selection,
                 (ox, oy),
                 (ox + dx, oy + dy),
-                readout_scale,
             );
             drawing_w.queue_draw();
         });
@@ -3416,7 +3408,7 @@ fn build_prompt_pill() -> gtk::Box {
     let restore = crate::APP_CONFIG
         .read()
         .scroll_capture_restore_region_shortcut()
-        .to_string();
+        .to_uppercase();
     let label = gtk::Label::new(Some(&format!(
         "Drag to capture the scrolling part of the screen  ·  {restore}: last region  ·  A: normal capture"
     )));
@@ -4063,28 +4055,20 @@ fn measured_pill_size(pill: &gtk::Box) -> (f64, f64) {
     pill_natural_size(pill)
 }
 
-/// Put the region's pixel size beside the corner being dragged.
+/// Put the region's size beside the corner being dragged.
 ///
-/// The overlay works in logical pixels and the capture comes back in
-/// device ones, so the number is scaled to match the file rather than
-/// the screen — a 2x display would otherwise report half of what gets
-/// saved.
-///
-/// `scale` is passed in rather than looked up: asking the compositor
-/// for it means spawning `hyprctl`, and this runs on every drag-update
-/// event. Doing that per motion made dragging a region look broken.
+/// In the overlay's own logical pixels, matching both the area capture
+/// and the editor's corner readout — the editor divides the image by
+/// the capture scale so a region reads at the size it looked on
+/// screen, and these should not disagree with it.
 fn show_readout(
     readout: &gtk::Box,
     label: &gtk::Label,
     selection: Selection,
     origin: (f64, f64),
     corner: (f64, f64),
-    scale: f64,
 ) {
-    let (w, h) = (
-        (selection.w * scale).round() as i64,
-        (selection.h * scale).round() as i64,
-    );
+    let (w, h) = (selection.w.round() as i64, selection.h.round() as i64);
     if w < 1 || h < 1 {
         readout.set_visible(false);
         return;

--- a/src/scroll_capture/mod.rs
+++ b/src/scroll_capture/mod.rs
@@ -17,7 +17,11 @@ use crate::capture;
 pub mod auto_scroll;
 mod stitch;
 
-const BACKDROP_ALPHA: f64 = 0.55;
+/// Dim behind the selection. Matches the area capture's shade
+/// (`.capture-shade` in `region_capture`): the two overlays are the
+/// same tool asking the same question, and a difference in weight
+/// reads as a difference in kind.
+const BACKDROP_ALPHA: f64 = 0.45;
 const BRACKET_LEN: f64 = 22.0;
 const BRACKET_WIDTH: f64 = 3.0;
 const PILL_GAP: f64 = 18.0;

--- a/src/scroll_capture/mod.rs
+++ b/src/scroll_capture/mod.rs
@@ -3410,10 +3410,16 @@ fn build_prompt_pill() -> gtk::Box {
     pill.add_css_class("scroll-capture-prompt");
     // Names the way out as well as the way in: this overlay is modal
     // and full-screen, and A is how you get to an ordinary capture
-    // without closing it and pressing a different keybind.
-    let label = gtk::Label::new(Some(
-        "Drag to capture the scrolling part of the screen  ·  A: normal capture",
-    ));
+    // without closing it and pressing a different keybind. The restore
+    // key is configurable, so the hint asks what it is rather than
+    // claiming R and being wrong for anyone who changed it.
+    let restore = crate::APP_CONFIG
+        .read()
+        .scroll_capture_restore_region_shortcut()
+        .to_string();
+    let label = gtk::Label::new(Some(&format!(
+        "Drag to capture the scrolling part of the screen  ·  {restore}: last region  ·  A: normal capture"
+    )));
     label.add_css_class("scroll-capture-prompt-label");
     pill.append(&label);
     pill

--- a/src/scroll_capture/mod.rs
+++ b/src/scroll_capture/mod.rs
@@ -711,6 +711,17 @@ pub struct ScrollCaptureOutcome {
     pub warning: Option<String>,
 }
 
+/// How the scroll overlay ended.
+pub enum ScrollRun {
+    /// A stitched capture came back.
+    Captured(ScrollCaptureOutcome),
+    /// The user asked for an ordinary capture instead. Nothing has
+    /// been captured, so handing over costs nothing.
+    SwitchToArea,
+    /// Escape, or the overlay closed without capturing.
+    Cancelled,
+}
+
 /// Selected phase only: hand the pointer and keyboard to the page inside the
 /// region while the cursor is over it, and take them back everywhere else.
 /// Hyprland pins pointer focus to any layer surface holding an exclusive
@@ -767,8 +778,9 @@ fn gdk_monitor_named(name: &str) -> Option<gtk::gdk::Monitor> {
         })
 }
 
-pub fn run(park_manual_pointer: bool) -> Result<Option<ScrollCaptureOutcome>> {
+pub fn run(park_manual_pointer: bool) -> Result<ScrollRun> {
     let result: Rc<RefCell<Option<ScrollCaptureOutcome>>> = Rc::new(RefCell::new(None));
+    let switch_to_area = Rc::new(std::cell::Cell::new(false));
 
     let app = gtk::Application::builder()
         .application_id("dev.tensaku.Tensaku.scroll-capture")
@@ -777,7 +789,10 @@ pub fn run(park_manual_pointer: bool) -> Result<Option<ScrollCaptureOutcome>> {
 
     {
         let result = Rc::clone(&result);
-        app.connect_activate(move |app| build_overlay(app, &result, park_manual_pointer));
+        let switch_to_area = Rc::clone(&switch_to_area);
+        app.connect_activate(move |app| {
+            build_overlay(app, &result, park_manual_pointer, &switch_to_area)
+        });
     }
 
     let exit_code = app.run_with_args::<&str>(&[]);
@@ -787,13 +802,21 @@ pub fn run(park_manual_pointer: bool) -> Result<Option<ScrollCaptureOutcome>> {
             exit_code
         ));
     }
-    Ok(result.borrow_mut().take())
+    // A capture wins over the switch: the flag can only be set while
+    // nothing has been captured, but reading it in this order means a
+    // race could never discard a finished stitch.
+    Ok(match result.borrow_mut().take() {
+        Some(outcome) => ScrollRun::Captured(outcome),
+        None if switch_to_area.get() => ScrollRun::SwitchToArea,
+        None => ScrollRun::Cancelled,
+    })
 }
 
 fn build_overlay(
     app: &gtk::Application,
     result: &Rc<RefCell<Option<ScrollCaptureOutcome>>>,
     park_manual_pointer: bool,
+    switch_to_area: &Rc<std::cell::Cell<bool>>,
 ) {
     let state = Rc::new(RefCell::new(OverlayState {
         phase: Phase::AwaitingDrag,
@@ -1150,6 +1173,8 @@ fn build_overlay(
     {
         let window_w = window.clone();
         let state_w = Rc::clone(&state);
+        let state_keys = Rc::clone(&state);
+        let switch_to_area = Rc::clone(switch_to_area);
         let drawing_w = drawing.clone();
         let prompt_w = prompt.clone();
         let action_pill_w = action_pill.clone();
@@ -1162,6 +1187,18 @@ fn build_overlay(
         );
         keys.connect_key_pressed(move |_, key, _, modifier| {
             if key == gtk::gdk::Key::Escape {
+                window_w.close();
+                return gtk::glib::Propagation::Stop;
+            }
+            // Before a region exists there is nothing to scroll, so A
+            // means the other kind of capture entirely — the mirror of
+            // the area overlay's S. Handing back beats making someone
+            // close this and press a different keybind.
+            if matches!(key, gtk::gdk::Key::a | gtk::gdk::Key::A)
+                && modifier.is_empty()
+                && matches!(state_keys.borrow().phase, Phase::AwaitingDrag)
+            {
+                switch_to_area.set(true);
                 window_w.close();
                 return gtk::glib::Propagation::Stop;
             }
@@ -3283,7 +3320,12 @@ fn build_prompt_pill() -> gtk::Box {
     let pill = gtk::Box::new(gtk::Orientation::Horizontal, 0);
     pill.add_css_class("scroll-capture-pill");
     pill.add_css_class("scroll-capture-prompt");
-    let label = gtk::Label::new(Some("Drag to capture the scrolling part of the screen."));
+    // Names the way out as well as the way in: this overlay is modal
+    // and full-screen, and A is how you get to an ordinary capture
+    // without closing it and pressing a different keybind.
+    let label = gtk::Label::new(Some(
+        "Drag to capture the scrolling part of the screen  ·  A: normal capture",
+    ));
     label.add_css_class("scroll-capture-prompt-label");
     pill.append(&label);
     pill

--- a/src/scroll_capture/mod.rs
+++ b/src/scroll_capture/mod.rs
@@ -97,7 +97,7 @@ const MOVE_HANDLE_RADIUS: f64 = 18.0;
 const MIN_SELECTION_SIZE: f64 = 32.0;
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
-enum ResizeHandle {
+pub(crate) enum ResizeHandle {
     TopLeft,
     Top,
     TopRight,
@@ -133,7 +133,7 @@ impl ResizeHandle {
     /// resize handles, `mouse_x/y` is the new position of the dragged edge
     /// or corner. For Move, the entire rect is translated by the delta
     /// between `drag_origin` and `(mouse_x, mouse_y)`.
-    fn apply(
+    pub(crate) fn apply(
         self,
         anchor: Selection,
         drag_origin: (f64, f64),
@@ -195,7 +195,7 @@ fn pointer_over_selected_page(sel: Selection, x: f64, y: f64) -> bool {
     inside && hit_test_handle(sel, x, y).is_none()
 }
 
-fn hit_test_handle(sel: Selection, x: f64, y: f64) -> Option<ResizeHandle> {
+pub(crate) fn hit_test_handle(sel: Selection, x: f64, y: f64) -> Option<ResizeHandle> {
     // 1) Corners win if you're near one (so you get diagonal resize even
     // though the edge bands overlap there).
     for h in [
@@ -239,11 +239,11 @@ fn hit_test_handle(sel: Selection, x: f64, y: f64) -> Option<ResizeHandle> {
 }
 
 #[derive(Default, Clone, Copy, Debug, PartialEq)]
-struct Selection {
-    x: f64,
-    y: f64,
-    w: f64,
-    h: f64,
+pub(crate) struct Selection {
+    pub(crate) x: f64,
+    pub(crate) y: f64,
+    pub(crate) w: f64,
+    pub(crate) h: f64,
 }
 
 impl Selection {

--- a/src/scroll_capture/mod.rs
+++ b/src/scroll_capture/mod.rs
@@ -1027,6 +1027,12 @@ fn build_overlay(
         let crosshair_drag = crosshair.clone();
         let readout_a = readout.clone();
         let readout_label_a = readout_label.clone();
+        // Read once: the monitor's scale can't change under a drag,
+        // and finding it costs a subprocess.
+        let readout_scale = crate::display::hyprland_focused_monitor()
+            .map(|m| m.scale as f64)
+            .unwrap_or(1.0)
+            .max(0.0001);
         drag.connect_drag_update(move |_, dx, dy| {
             let mut s = state.borrow_mut();
             if !s.drag_active {
@@ -1057,7 +1063,14 @@ fn build_overlay(
                     let selection = s.selection;
                     let origin = s.drag_origin;
                     drop(s);
-                    show_readout(&readout_a, &readout_label_a, selection, origin, (ox + dx, oy + dy));
+                    show_readout(
+                        &readout_a,
+                        &readout_label_a,
+                        selection,
+                        origin,
+                        (ox + dx, oy + dy),
+                        readout_scale,
+                    );
                     drawing_w.queue_draw();
                     return;
                 }
@@ -1088,7 +1101,14 @@ fn build_overlay(
             };
             let selection = s.selection;
             drop(s);
-            show_readout(&readout_a, &readout_label_a, selection, (ox, oy), (ox + dx, oy + dy));
+            show_readout(
+                &readout_a,
+                &readout_label_a,
+                selection,
+                (ox, oy),
+                (ox + dx, oy + dy),
+                readout_scale,
+            );
             drawing_w.queue_draw();
         });
     }
@@ -4043,17 +4063,18 @@ fn measured_pill_size(pill: &gtk::Box) -> (f64, f64) {
 /// device ones, so the number is scaled to match the file rather than
 /// the screen — a 2x display would otherwise report half of what gets
 /// saved.
+///
+/// `scale` is passed in rather than looked up: asking the compositor
+/// for it means spawning `hyprctl`, and this runs on every drag-update
+/// event. Doing that per motion made dragging a region look broken.
 fn show_readout(
     readout: &gtk::Box,
     label: &gtk::Label,
     selection: Selection,
     origin: (f64, f64),
     corner: (f64, f64),
+    scale: f64,
 ) {
-    let scale = crate::display::hyprland_focused_monitor()
-        .map(|m| m.scale as f64)
-        .unwrap_or(1.0)
-        .max(0.0001);
     let (w, h) = (
         (selection.w * scale).round() as i64,
         (selection.h * scale).round() as i64,

--- a/src/scroll_capture/mod.rs
+++ b/src/scroll_capture/mod.rs
@@ -945,6 +945,20 @@ fn build_overlay(
     crosshair[1].set_valign(gtk::Align::Start);
     crosshair[1].set_size_request(-1, 1);
 
+    // Live pixel size of the region, beside the corner being dragged.
+    // Same pill and the same placement rule as the area capture — the
+    // rule lives there because that overlay owns the geometry helpers.
+    let readout_label = gtk::Label::new(None);
+    readout_label.add_css_class("scroll-capture-prompt-label");
+    let readout = gtk::Box::new(gtk::Orientation::Horizontal, 0);
+    readout.add_css_class("scroll-capture-pill");
+    readout.add_css_class("capture-readout");
+    readout.append(&readout_label);
+    readout.set_halign(gtk::Align::Start);
+    readout.set_valign(gtk::Align::Start);
+    readout.set_visible(false);
+    overlay.add_overlay(&readout);
+
     action_pill.set_visible(false);
     capturing_pill.set_visible(false);
 
@@ -1007,6 +1021,8 @@ fn build_overlay(
         let action_pill_w = action_pill.clone();
         let capturing_pill_w = capturing_pill.clone();
         let crosshair_drag = crosshair.clone();
+        let readout_a = readout.clone();
+        let readout_label_a = readout_label.clone();
         drag.connect_drag_update(move |_, dx, dy| {
             let mut s = state.borrow_mut();
             if !s.drag_active {
@@ -1034,7 +1050,10 @@ fn build_overlay(
                         w: dx.abs(),
                         h: dy.abs(),
                     };
+                    let selection = s.selection;
+                    let origin = s.drag_origin;
                     drop(s);
+                    show_readout(&readout_a, &readout_label_a, selection, origin, (ox + dx, oy + dy));
                     drawing_w.queue_draw();
                     return;
                 }
@@ -1063,11 +1082,14 @@ fn build_overlay(
                 w: dx.abs(),
                 h: dy.abs(),
             };
+            let selection = s.selection;
             drop(s);
+            show_readout(&readout_a, &readout_label_a, selection, (ox, oy), (ox + dx, oy + dy));
             drawing_w.queue_draw();
         });
     }
     {
+        let readout_end = readout.clone();
         let state = Rc::clone(&state);
         let drawing_w = drawing.clone();
         let window_w = window.clone();
@@ -1076,6 +1098,9 @@ fn build_overlay(
         let horiz_btn_w = horiz_auto_scroll.clone();
         let prompt_w = prompt.clone();
         drag.connect_drag_end(move |_, _dx, _dy| {
+            // The size was answering "how big is this drag"; the drag
+            // is over, and the action pill takes the screen from here.
+            readout_end.set_visible(false);
             let mut s = state.borrow_mut();
             if !s.drag_active {
                 // Tap that missed a button or handle — leave state alone.
@@ -4003,6 +4028,44 @@ fn measured_pill_size(pill: &gtk::Box) -> (f64, f64) {
     // stale immediately after pause/end content changes. Use the same
     // margin-neutral natural size for every placement and input-region update.
     pill_natural_size(pill)
+}
+
+/// Put the region's pixel size beside the corner being dragged.
+///
+/// The overlay works in logical pixels and the capture comes back in
+/// device ones, so the number is scaled to match the file rather than
+/// the screen — a 2x display would otherwise report half of what gets
+/// saved.
+fn show_readout(
+    readout: &gtk::Box,
+    label: &gtk::Label,
+    selection: Selection,
+    origin: (f64, f64),
+    corner: (f64, f64),
+) {
+    let scale = crate::display::hyprland_focused_monitor()
+        .map(|m| m.scale as f64)
+        .unwrap_or(1.0)
+        .max(0.0001);
+    let (w, h) = (
+        (selection.w * scale).round() as i64,
+        (selection.h * scale).round() as i64,
+    );
+    if w < 1 || h < 1 {
+        readout.set_visible(false);
+        return;
+    }
+    label.set_text(&format!("{w} × {h}"));
+    readout.set_visible(true);
+
+    let (pw, ph) = pill_natural_size(readout);
+    let screen = readout
+        .root()
+        .map(|r| (r.width() as f64, r.height() as f64))
+        .unwrap_or((0.0, 0.0));
+    let (x, y) = crate::region_capture::readout_position(origin, corner, (pw, ph), screen);
+    readout.set_margin_start(x as i32);
+    readout.set_margin_top(y as i32);
 }
 
 fn draw_backdrop(cr: &cairo::Context, w: f64, h: f64, s: &OverlayState) {

--- a/src/scroll_capture/mod.rs
+++ b/src/scroll_capture/mod.rs
@@ -923,6 +923,24 @@ fn build_overlay(
     // and pointer wheel pass-through is governed by the surface input
     // region, not the keyboard mode.
 
+    // Pointer guides, shown until a region exists. Widgets rather than
+    // cairo lines in `draw_backdrop`: they move with every motion
+    // event, and moving two strips lets GTK composite them instead of
+    // repainting the whole backdrop to shift a line by a pixel.
+    let crosshair: [gtk::Box; 2] = std::array::from_fn(|_| {
+        let guide = gtk::Box::new(gtk::Orientation::Horizontal, 0);
+        guide.add_css_class("capture-crosshair");
+        guide.set_visible(false);
+        overlay.add_overlay(&guide);
+        guide
+    });
+    crosshair[0].set_halign(gtk::Align::Start);
+    crosshair[0].set_valign(gtk::Align::Fill);
+    crosshair[0].set_size_request(1, -1);
+    crosshair[1].set_halign(gtk::Align::Fill);
+    crosshair[1].set_valign(gtk::Align::Start);
+    crosshair[1].set_size_request(-1, 1);
+
     action_pill.set_visible(false);
     capturing_pill.set_visible(false);
 
@@ -984,6 +1002,7 @@ fn build_overlay(
         let prompt_w = prompt.clone();
         let action_pill_w = action_pill.clone();
         let capturing_pill_w = capturing_pill.clone();
+        let crosshair_drag = crosshair.clone();
         drag.connect_drag_update(move |_, dx, dy| {
             let mut s = state.borrow_mut();
             if !s.drag_active {
@@ -995,6 +1014,9 @@ fn build_overlay(
                 if s.resize_handle.is_none() {
                     s.phase = Phase::Dragging;
                     drop(s);
+                    for guide in &crosshair_drag {
+                        guide.set_visible(false);
+                    }
                     prompt_w.set_visible(false);
                     action_pill_w.set_visible(false);
                     capturing_pill_w.set_visible(false);
@@ -1121,10 +1143,20 @@ fn build_overlay(
         let state = Rc::clone(&state);
         let drawing_w = drawing.clone();
         let window_w = window.clone();
+        let crosshair_w = crosshair.clone();
         motion.connect_motion(move |_, x, y| {
             let phase = state.borrow().phase;
+            // Guides while a region is still being chosen; once one
+            // exists it is the thing being aimed, and they would be two
+            // more lines over it.
+            let aiming = matches!(phase, Phase::AwaitingDrag);
+            crosshair_w[0].set_margin_start(x.round().max(0.0) as i32);
+            crosshair_w[1].set_margin_top(y.round().max(0.0) as i32);
+            for guide in &crosshair_w {
+                guide.set_visible(aiming);
+            }
             if !matches!(phase, Phase::Selected) {
-                drawing_w.set_cursor_from_name(Some("default"));
+                drawing_w.set_cursor_from_name(Some(if aiming { "crosshair" } else { "default" }));
                 return;
             }
             update_selected_keyboard_zone(&state, &window_w, x, y);

--- a/src/scroll_capture/mod.rs
+++ b/src/scroll_capture/mod.rs
@@ -22,6 +22,10 @@ mod stitch;
 /// same tool asking the same question, and a difference in weight
 /// reads as a difference in kind.
 const BACKDROP_ALPHA: f64 = 0.45;
+
+/// Gap between the prompt pill and the bottom of the screen. Matches
+/// the area capture's hint, which sits at the same height.
+const PROMPT_MARGIN_BOTTOM: f64 = 48.0;
 const BRACKET_LEN: f64 = 22.0;
 const BRACKET_WIDTH: f64 = 3.0;
 const PILL_GAP: f64 = 18.0;
@@ -1222,7 +1226,10 @@ fn build_overlay(
         drawing.connect_resize(move |_, w, h| {
             let (pw, ph) = pill_natural_size(&prompt_w);
             let x = ((w as f64 - pw) / 2.0).max(0.0);
-            let y = ((h as f64 - ph) / 2.0).max(0.0);
+            // Along the bottom rather than centred: the instructions
+            // are read once, and the middle of the screen is where the
+            // region being chosen actually is.
+            let y = (h as f64 - ph - PROMPT_MARGIN_BOTTOM).max(0.0);
             prompt_w.set_margin_start(x as i32);
             prompt_w.set_margin_top(y as i32);
         });

--- a/src/scroll_capture/style.css
+++ b/src/scroll_capture/style.css
@@ -176,3 +176,9 @@
 .capture-crosshair {
   background: rgba(255, 255, 255, 0.22);
 }
+
+/* The drag size readout: the prompt pill, tightened up — it sits next
+   to the pointer rather than centred on screen. */
+.capture-readout {
+  padding: 4px 10px;
+}

--- a/src/scroll_capture/style.css
+++ b/src/scroll_capture/style.css
@@ -167,3 +167,12 @@
 .scroll-capture-inside-auto:hover {
   background-color: rgba(40, 50, 70, 0.95);
 }
+
+/* Pointer guides before a region is dragged — the same faint white
+   lines the area capture shows, under the same class name. Widgets
+   rather than painted lines: they follow the pointer on every motion
+   event, and compositing two strips is free where redrawing a 6K
+   backdrop is not. */
+.capture-crosshair {
+  background: rgba(255, 255, 255, 0.22);
+}

--- a/src/sketch_board.rs
+++ b/src/sketch_board.rs
@@ -84,6 +84,9 @@ pub enum SketchBoardInput {
     /// editor back.
     PinEdit,
 
+    /// The pinned window's Copy-image button.
+    PinCopyImage,
+
     /// The pinned window's Copy-path button.
     PinCopyPath,
 
@@ -699,6 +702,14 @@ pub struct SketchBoard {
     /// dropping the handle would close the window the moment it
     /// opened — and so a completed copy can confirm itself on it.
     pinned: RefCell<Option<crate::pin::Pin>>,
+    /// The image the pin is showing.
+    ///
+    /// Kept because the editor's window is hidden while a pin is up,
+    /// and every path through the renderer needs it visible: a hidden
+    /// GLArea never draws, so a render request made from the pin
+    /// never comes back. Copying and saving work from these pixels
+    /// instead, which are already exactly what was pinned.
+    pinned_image: RefCell<Option<Pixbuf>>,
     /// Last (selected drawable id, size, size-factor) tuple we pushed
     /// to the toolbar via `SelectionStyleChanged`. We re-emit when
     /// any of these change — flips of the active selection AND
@@ -1512,7 +1523,6 @@ impl SketchBoard {
             None => Self::write_pin_snapshot(image),
         };
         let drag_path = saved.clone().or_else(|| snapshot.clone());
-        let copy_image = image.clone();
         let copy_sender = sender.input_sender().clone();
         let path_sender = sender.input_sender().clone();
         let edit_sender = sender.input_sender().clone();
@@ -1526,8 +1536,7 @@ impl SketchBoard {
                 // copy is byte-identical to one made from the editor,
                 // including the configured `copy-command`.
                 on_copy: Box::new(move || {
-                    let _ = copy_image;
-                    copy_sender.emit(SketchBoardInput::ToolbarEvent(ToolbarEvent::CopyClipboard));
+                    copy_sender.emit(SketchBoardInput::PinCopyImage);
                 }),
                 on_copy_path: Box::new(move || {
                     path_sender.emit(SketchBoardInput::PinCopyPath);
@@ -1548,6 +1557,7 @@ impl SketchBoard {
                 let _ = fs::remove_file(&snapshot);
             });
         }
+        *self.pinned_image.borrow_mut() = Some(image.clone());
         *self.pinned.borrow_mut() = Some(pin);
         sender.output_sender().emit(SketchBoardOutput::PinOpened);
     }
@@ -5887,6 +5897,12 @@ impl Component for SketchBoard {
                     .emit(SketchBoardOutput::PinEditRequested);
                 ToolUpdateResult::Unmodified
             }
+            SketchBoardInput::PinCopyImage => {
+                if let Some(image) = self.pinned_image.borrow().as_ref() {
+                    self.handle_copy_clipboard(image);
+                }
+                ToolUpdateResult::Unmodified
+            }
             SketchBoardInput::PinCopyPath => {
                 // A pinned shot has often never been saved, so the
                 // path it would be copied from doesn't exist yet.
@@ -5894,19 +5910,30 @@ impl Component for SketchBoard {
                 // honestly mean there, and `handle_save` records the
                 // path synchronously, so the copy that follows in the
                 // same action list sees it.
+                // Straight from the pinned pixels, never through the
+                // renderer: the editor's window is hidden while a pin
+                // is up, and a hidden GLArea never draws, so a render
+                // request would be a copy that silently never happens.
+                let image = self.pinned_image.borrow().clone();
                 if self.last_saved_filepath.borrow().is_some() {
                     self.handle_copy_filepath();
-                } else if APP_CONFIG.read().output_filename().is_some() {
-                    self.renderer
-                        .request_render(&[Action::SaveToFile, Action::CopyFilepathToClipboard]);
-                } else {
-                    // Nowhere configured to save to, so ask. Save As
-                    // carries the rest of the action list into its
-                    // callback, which is how the copy still happens
-                    // after a dialog that returns whenever the user
-                    // gets round to it.
-                    self.renderer
-                        .request_render(&[Action::SaveToFileAs, Action::CopyFilepathToClipboard]);
+                } else if let Some(image) = image {
+                    if APP_CONFIG.read().output_filename().is_some() {
+                        self.handle_save(&image);
+                        self.handle_copy_filepath();
+                    } else {
+                        // Nowhere configured to save to, so ask. Save
+                        // As carries the follow-up into its callback,
+                        // which is how the copy still happens after a
+                        // dialog that returns whenever the user gets
+                        // round to it.
+                        self.handle_save_as(
+                            true,
+                            image,
+                            sender,
+                            vec![Action::CopyFilepathToClipboard],
+                        );
+                    }
                 }
                 ToolUpdateResult::Unmodified
             }
@@ -6357,6 +6384,7 @@ impl Component for SketchBoard {
             im_context,
             last_saved_filepath: RefCell::new(None),
             pinned: RefCell::new(None),
+            pinned_image: RefCell::new(None),
             last_synced_selection: None,
             last_was_multi_selection: false,
             tool_before_crop: None,

--- a/src/sketch_board.rs
+++ b/src/sketch_board.rs
@@ -1248,6 +1248,25 @@ impl SketchBoard {
         dirs.place_state_file(SAVE_AS_LAST_DIR_FILE).ok()
     }
 
+    /// `untitled-N.png`, where N is one past the highest already in
+    /// `dir`. Counting from what is there rather than from one means a
+    /// second save doesn't land on the first, and a directory full of
+    /// them still numbers forward after some are deleted.
+    fn next_untitled_name(dir: &Path) -> String {
+        let highest = fs::read_dir(dir)
+            .into_iter()
+            .flatten()
+            .flatten()
+            .filter_map(|entry| {
+                let name = entry.file_name().to_string_lossy().into_owned();
+                let stem = name.strip_suffix(".png")?;
+                stem.strip_prefix("untitled-")?.parse::<u32>().ok()
+            })
+            .max()
+            .unwrap_or(0);
+        format!("untitled-{}.png", highest + 1)
+    }
+
     fn save_as_initial_dir(
         last_dir_file: Option<&Path>,
         configured_output_path: Option<&Path>,
@@ -1352,10 +1371,15 @@ impl SketchBoard {
             Self::save_as_last_dir_file().as_deref(),
             configured_output_path.as_deref(),
         );
+        // A configured output name is an explicit choice, so it wins.
+        // Otherwise suggest the next untitled: an empty name box means
+        // typing one from scratch every time, and a fixed suggestion
+        // means overwriting yesterday's shot.
         let suggested_filename = configured_output_path
             .as_deref()
             .and_then(Path::file_name)
-            .map(|name| name.to_string_lossy().into_owned());
+            .map(|name| name.to_string_lossy().into_owned())
+            .or_else(|| initial_dir.as_deref().map(Self::next_untitled_name));
 
         let data = match pixbuf.save_to_bufferv("png", &Vec::new()) {
             Ok(d) => d,

--- a/src/state.rs
+++ b/src/state.rs
@@ -115,6 +115,8 @@ pub struct PersistedState {
     /// key. Incidental UI state, not a preference — hence state.toml.
     #[serde(default)]
     pub scroll_capture_last_region: Option<[f64; 4]>,
+    #[serde(default)]
+    pub capture_last_region: Option<[f64; 4]>,
     /// Legacy Preferences value; migrated to `config.toml` at startup.
     #[serde(default)]
     pub park_pointer_during_manual_scroll_capture: Option<bool>,
@@ -440,6 +442,24 @@ pub fn load_scroll_capture_last_region() -> Option<[f64; 4]> {
 pub fn save_scroll_capture_last_region(region: [f64; 4]) {
     let mut state = load();
     state.scroll_capture_last_region = Some(region);
+    save(&state);
+}
+
+/// The region (`[x, y, w, h]`, overlay-logical px) of the most recent
+/// area capture, or `None` when none has run yet.
+///
+/// Kept apart from the scrolling capture's: the two are used for
+/// different things -- a column of a page versus a panel of an app --
+/// and sharing one slot would have each overwrite the other's.
+pub fn load_capture_last_region() -> Option<[f64; 4]> {
+    load().capture_last_region
+}
+
+/// Remember the region an area capture just took, so the next one can
+/// reselect it and frame the shot identically.
+pub fn save_capture_last_region(region: [f64; 4]) {
+    let mut state = load();
+    state.capture_last_region = Some(region);
     save(&state);
 }
 

--- a/src/tools/text.rs
+++ b/src/tools/text.rs
@@ -223,17 +223,16 @@ impl TextBackground {
 /// the text so the look holds at every size.
 const OUTLINE_WIDTH_RATIO: f32 = 0.17;
 
-/// The ink that reads against `color`: white behind dark text, black
-/// behind light. Same luminance rule the counter badge uses to pick
-/// its digit colour.
-/// <https://en.wikipedia.org/wiki/Luma_(video)>
-fn outline_color(color: femtovg::Color) -> femtovg::Color {
-    let luminance = 0.2126 * color.r + 0.7152 * color.g + 0.0722 * color.b;
-    if luminance > 0.5 {
-        femtovg::Color::rgba(0, 0, 0, 235)
-    } else {
-        femtovg::Color::rgba(255, 255, 255, 235)
-    }
+/// The outline colour: white, whatever the text is.
+///
+/// A luminance rule would flip it to black behind pale text, which is
+/// tidier in theory and wrong in practice — screenshots are mostly
+/// light UI, and a black halo reads as a drop shadow rather than as
+/// the crisp cut-out CleanShot X gets. White is also what makes an
+/// annotation in any accent colour hold together over a busy
+/// background.
+fn outline_color() -> femtovg::Color {
+    femtovg::Color::rgba(255, 255, 255, 235)
 }
 
 #[derive(Clone, Debug)]
@@ -934,7 +933,7 @@ impl Drawable for Text {
         // that.
         let outline_paint = if matches!(self.background, TextBackground::Outlined) {
             let mut paint = base_paint.clone();
-            paint.set_color(outline_color(self.style.color.into()));
+            paint.set_color(outline_color());
             let font_size = self
                 .style
                 .size

--- a/src/ui/toolbars.rs
+++ b/src/ui/toolbars.rs
@@ -99,6 +99,19 @@ fn show_tooltip(popover: &gtk::Popover) {
     popover.popup();
 }
 
+/// Pop down whatever tooltip is showing, if any.
+///
+/// For gestures that move the widget out from under the pointer: GTK
+/// keeps re-triggering the hover, and the tooltip tags along beside
+/// the thing being dragged.
+pub fn dismiss_active_tooltip() {
+    ACTIVE_TOOLTIP.with(|active| {
+        if let Some(popover) = active.borrow_mut().take() {
+            popover.popdown();
+        }
+    });
+}
+
 fn hide_tooltip(popover: &gtk::Popover) {
     popover.popdown();
     ACTIVE_TOOLTIP.with(|active| {


### PR DESCRIPTION



## 🤖 New release

* `tensaku_cli`: 0.26.7 -> 0.27.0 (⚠ API breaking changes)
* `tensaku`: 0.26.7 -> 0.27.0

### ⚠ `tensaku_cli` breaking changes

```text
--- failure constructible_struct_adds_field: externally-constructible struct adds field ---

Description:
A pub struct constructible with a struct literal has a new pub field. Existing struct literals must be updated to include the new field.
        ref: https://doc.rust-lang.org/reference/expressions/struct-expr.html
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.48.0/src/lints/constructible_struct_adds_field.ron

Failed in:
  field CommandLine.capture in /tmp/.tmp20Tslw/tensaku/cli/src/command_line.rs:67
```

<details><summary><i><b>Changelog</b></i></summary><p>


## `tensaku`

<blockquote>

## [0.27.0](https://github.com/jondkinney/tensaku/compare/v0.26.7...v0.27.0) - 2026-08-21

### Added

- *(pin)* place and stack pins on sway too
- *(pin)* degrade gracefully off Hyprland
- *(pin)* shape the pin like the display
- *(pin,capture)* square stacked pins, click-to-edit, untitled names
- *(capture)* the size pill takes the shot, and the puck matches
- *(capture)* a shutter button beside the restored region's puck
- *(capture)* the cursor says what a restored region will do
- *(capture)* grips and a move puck on a restored region
- *(capture)* adjust a restored region, and hide its measurement
- *(capture)* R restores the last region
- *(capture)* show the selection's pixel size while dragging
- *(scroll-capture)* the same pointer guides as the area capture
- *(capture)* A switches scrolling capture back to a normal one
- *(capture)* crosshair guides before the drag starts
- *(capture)* own the region selection, with window and mode switching
- *(pin)* tooltips, copy confirmations, and drag-out
- *(pin)* copy path saves the shot when it has none
- *(canvas)* the plain wheel walks whichever axis overflows
- *(pin)* pin the finished shot to the desktop
- *(spotlight)* Alt+wheel adjusts the loupe
- *(spotlight)* a magnification slider turns a spotlight into a loupe
- *(text)* an outlined style that reads over anything
- *(blur)* a Secure checkbox states what each mode can undo
- *(shapes)* f toggles fill on any fillable selection
- *(shapes)* a single r / e toggles a selected shape's fill
- *(canvas)* right-click an annotation to restack it
- *(stacking)* text lands above artwork, counters above text
- *(pointer)* plain wheel zooms when the Pointer is armed
- *(prefs)* remove the invert-scrolling preference
- *(canvas)* plain wheel sizes the next annotation
- *(counter)* preview the badge on the canvas, not in the cursor
- *(counter)* the cursor previews the badge it will stamp
- *(counter)* stamp the counter over text instead of grabbing it
- *(shapes)* shape tool buttons show their own fill, and widen the double-tap
- *(shapes)* double-tap a shape's key to toggle its fill, replacing F
- *(selection)* grab large annotations by their border, draw in their interior

### Fixed

- *(pin)* crop the preview to the capture's top, not its middle
- *(pin)* drop the mat and the rounded corner
- *(pin)* float, pin and place through the Lua dispatch API
- *(pin)* tooltips use the app's own, and the drag polls twice a frame
- *(pin)* the drag follows the pointer itself
- *(pin)* drag follows the pointer, and tooltips get out of the way
- *(pin)* slots follow where pins are, and moving one keeps up
- *(capture)* the shutter pill and puck carry their own cursors
- *(pin)* copy works, preview shows the shot, pins stack
- *(capture)* puck back to centre, size and shutter parked beneath it
- *(capture)* size readouts agree with the editor
- *(scroll-capture)* stop spawning hyprctl on every drag event
- *(capture)* hints along the bottom, not across the middle
- *(capture)* don't capture the overlay you just switched away from
- *(scroll-capture)* dim to the same weight as the area capture
- *(capture)* the area overlay wears the scroll capture's pill
- *(capture)* centre the area overlay's hint like the scroll one
- *(text)* the outline is white, like CleanShot X
- *(capture)* crosshair pointer while aiming a region
- *(capture)* cache the backdrop; stop toasting the saved text style
- *(capture)* take the picture before the overlay exists
- *(capture)* let the overlay leave the screen before capturing it
- *(capture)* merge the --capture flag into the configuration
- *(pin)* back every pin with a file so the drag carries a path
- *(pin)* drag a thumbnail, not the whole capture
- *(pin)* ask where to save when nothing is configured
- *(pin)* render the pixels the pin needs
- *(text)* Ctrl+Shift+wheel reaches the outlined style
- *(spotlight)* make magnification global, like darkness
- *(spotlight)* render the loupe in the pass that renders spotlights
- *(blur)* stop the secure blur seeding itself from its own glow
- *(blur)* put Secure beside the picker, not inside it
- *(ellipse)* grab the curve, not the box around it
- *(picking)* size the border-grab band in screen pixels
- *(shapes)* apply the r / e fill toggle instead of dropping it
- *(canvas)* stop inverting the compositor's scroll delta
- *(counter)* tighten the badge's lead on the pointer
- *(counter)* system cursor, offset badge
- *(counter)* move the pointer off the number it previews
- *(counter)* the cursor over text matches what the click does
- *(shapes)* keep each shape's fill toggle to that shape
- *(toolbar)* bundle the shape buttons' filled glyphs
- *(selection)* dismiss a selection before drawing inside a large annotation
- *(text)* clicking away from an in-progress text only ends it
- *(text)* grab an existing text box rather than stacking a new one on it
- *(input)* ignore modifiers left over from the launch chord
- *(arrow)* thicken only the tail when zoomed out
- *(canvas)* stop the expanded background showing a line per expansion
- *(omarchy)* opt out of default window opacity, wiring through Lua
- *(selection)* shrink the selection halo with the artwork when zoomed out
- *(canvas)* settle the edge extension away from the boundary
- *(canvas)* extend the image edge per line instead of one flat colour
- *(text)* wrap auto-fit text at the image edge while typing
- *(stitch)* keep a fixed edge's drop shadow out of every seam
- *(stitch)* crop viewport-fixed bands out of the motion search
- *(scroll-capture)* let the page inside a selected region take wheel and keys
- *(scroll-capture)* target the overlay's monitor for capture and pointer warps
- *(render)* tile the spotlight overlay past GL texture limits

### Other

- *(region-capture)* run cargo fmt
- *(pin)* let the compositor move the pin
- *(pin)* lead the pointer by the latency instead of chasing it
- *(pin)* read the pointer off-thread, move on the frame clock
- *(capture)* composite the selection instead of painting it
- Revert "feat(pointer): plain wheel zooms when the Pointer is armed"
- drop the two removed preferences from the README
- *(canvas)* add probes for tile seams and flat-render uniformity
- *(canvas)* grow the raster by re-viewing it, not by copying it
- *(canvas)* add a grow-raster digest harness
- *(canvas)* reuse background textures across an auto-grow
- *(blur)* read back only the blurred region, and stop leaking textures
- *(canvas)* stop copying the raster twice on every re-upload
- *(canvas)* add an env-gated frame profiler
- update star history chart
- update star history chart
- update star history chart
- update star history chart
- *(stitch)* use is_multiple_of in the sparse-doc fixture
- *(stitch)* replay harness takes TENSAKU_STITCH_REPLAY_AXIS
- update star history chart
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).