### PR TITLE
chore: release v0.27.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,132 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.27.0](https://github.com/jondkinney/tensaku/compare/v0.26.7...v0.27.0) - 2026-08-21
+
+### Added
+
+- *(pin)* place and stack pins on sway too
+- *(pin)* degrade gracefully off Hyprland
+- *(pin)* shape the pin like the display
+- *(pin,capture)* square stacked pins, click-to-edit, untitled names
+- *(capture)* the size pill takes the shot, and the puck matches
+- *(capture)* a shutter button beside the restored region's puck
+- *(capture)* the cursor says what a restored region will do
+- *(capture)* grips and a move puck on a restored region
+- *(capture)* adjust a restored region, and hide its measurement
+- *(capture)* R restores the last region
+- *(capture)* show the selection's pixel size while dragging
+- *(scroll-capture)* the same pointer guides as the area capture
+- *(capture)* A switches scrolling capture back to a normal one
+- *(capture)* crosshair guides before the drag starts
+- *(capture)* own the region selection, with window and mode switching
+- *(pin)* tooltips, copy confirmations, and drag-out
+- *(pin)* copy path saves the shot when it has none
+- *(canvas)* the plain wheel walks whichever axis overflows
+- *(pin)* pin the finished shot to the desktop
+- *(spotlight)* Alt+wheel adjusts the loupe
+- *(spotlight)* a magnification slider turns a spotlight into a loupe
+- *(text)* an outlined style that reads over anything
+- *(blur)* a Secure checkbox states what each mode can undo
+- *(shapes)* f toggles fill on any fillable selection
+- *(shapes)* a single r / e toggles a selected shape's fill
+- *(canvas)* right-click an annotation to restack it
+- *(stacking)* text lands above artwork, counters above text
+- *(pointer)* plain wheel zooms when the Pointer is armed
+- *(prefs)* remove the invert-scrolling preference
+- *(canvas)* plain wheel sizes the next annotation
+- *(counter)* preview the badge on the canvas, not in the cursor
+- *(counter)* the cursor previews the badge it will stamp
+- *(counter)* stamp the counter over text instead of grabbing it
+- *(shapes)* shape tool buttons show their own fill, and widen the double-tap
+- *(shapes)* double-tap a shape's key to toggle its fill, replacing F
+- *(selection)* grab large annotations by their border, draw in their interior
+
+### Fixed
+
+- *(pin)* crop the preview to the capture's top, not its middle
+- *(pin)* drop the mat and the rounded corner
+- *(pin)* float, pin and place through the Lua dispatch API
+- *(pin)* tooltips use the app's own, and the drag polls twice a frame
+- *(pin)* the drag follows the pointer itself
+- *(pin)* drag follows the pointer, and tooltips get out of the way
+- *(pin)* slots follow where pins are, and moving one keeps up
+- *(capture)* the shutter pill and puck carry their own cursors
+- *(pin)* copy works, preview shows the shot, pins stack
+- *(capture)* puck back to centre, size and shutter parked beneath it
+- *(capture)* size readouts agree with the editor
+- *(scroll-capture)* stop spawning hyprctl on every drag event
+- *(capture)* hints along the bottom, not across the middle
+- *(capture)* don't capture the overlay you just switched away from
+- *(scroll-capture)* dim to the same weight as the area capture
+- *(capture)* the area overlay wears the scroll capture's pill
+- *(capture)* centre the area overlay's hint like the scroll one
+- *(text)* the outline is always white
+- *(capture)* crosshair pointer while aiming a region
+- *(capture)* cache the backdrop; stop toasting the saved text style
+- *(capture)* take the picture before the overlay exists
+- *(capture)* let the overlay leave the screen before capturing it
+- *(capture)* merge the --capture flag into the configuration
+- *(pin)* back every pin with a file so the drag carries a path
+- *(pin)* drag a thumbnail, not the whole capture
+- *(pin)* ask where to save when nothing is configured
+- *(pin)* render the pixels the pin needs
+- *(text)* Ctrl+Shift+wheel reaches the outlined style
+- *(spotlight)* make magnification global, like darkness
+- *(spotlight)* render the loupe in the pass that renders spotlights
+- *(blur)* stop the secure blur seeding itself from its own glow
+- *(blur)* put Secure beside the picker, not inside it
+- *(ellipse)* grab the curve, not the box around it
+- *(picking)* size the border-grab band in screen pixels
+- *(shapes)* apply the r / e fill toggle instead of dropping it
+- *(canvas)* stop inverting the compositor's scroll delta
+- *(counter)* tighten the badge's lead on the pointer
+- *(counter)* system cursor, offset badge
+- *(counter)* move the pointer off the number it previews
+- *(counter)* the cursor over text matches what the click does
+- *(shapes)* keep each shape's fill toggle to that shape
+- *(toolbar)* bundle the shape buttons' filled glyphs
+- *(selection)* dismiss a selection before drawing inside a large annotation
+- *(text)* clicking away from an in-progress text only ends it
+- *(text)* grab an existing text box rather than stacking a new one on it
+- *(input)* ignore modifiers left over from the launch chord
+- *(arrow)* thicken only the tail when zoomed out
+- *(canvas)* stop the expanded background showing a line per expansion
+- *(omarchy)* opt out of default window opacity, wiring through Lua
+- *(selection)* shrink the selection halo with the artwork when zoomed out
+- *(canvas)* settle the edge extension away from the boundary
+- *(canvas)* extend the image edge per line instead of one flat colour
+- *(text)* wrap auto-fit text at the image edge while typing
+- *(stitch)* keep a fixed edge's drop shadow out of every seam
+- *(stitch)* crop viewport-fixed bands out of the motion search
+- *(scroll-capture)* let the page inside a selected region take wheel and keys
+- *(scroll-capture)* target the overlay's monitor for capture and pointer warps
+- *(render)* tile the spotlight overlay past GL texture limits
+
+### Other
+
+- *(region-capture)* run cargo fmt
+- *(pin)* let the compositor move the pin
+- *(pin)* lead the pointer by the latency instead of chasing it
+- *(pin)* read the pointer off-thread, move on the frame clock
+- *(capture)* composite the selection instead of painting it
+- Revert "feat(pointer): plain wheel zooms when the Pointer is armed"
+- drop the two removed preferences from the README
+- *(canvas)* add probes for tile seams and flat-render uniformity
+- *(canvas)* grow the raster by re-viewing it, not by copying it
+- *(canvas)* add a grow-raster digest harness
+- *(canvas)* reuse background textures across an auto-grow
+- *(blur)* read back only the blurred region, and stop leaking textures
+- *(canvas)* stop copying the raster twice on every re-upload
+- *(canvas)* add an env-gated frame profiler
+- update star history chart
+- update star history chart
+- update star history chart
+- update star history chart
+- *(stitch)* use is_multiple_of in the sparse-doc fixture
+- *(stitch)* replay harness takes TENSAKU_STITCH_REPLAY_AXIS
+- update star history chart
+
 ## [0.26.7](https://github.com/jondkinney/tensaku/compare/v0.26.6...v0.26.7) - 2026-08-15
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1761,7 +1761,7 @@ checksum = "df7f62577c25e07834649fc3b39fafdc597c0a3527dc1c60129201ccfcbaa50c"
 
 [[package]]
 name = "tensaku"
-version = "0.26.7"
+version = "0.27.0"
 dependencies = [
  "anyhow",
  "chrono",
@@ -1802,7 +1802,7 @@ dependencies = [
 
 [[package]]
 name = "tensaku_cli"
-version = "0.26.7"
+version = "0.27.0"
 dependencies = [
  "clap",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -88,7 +88,7 @@ clap_mangen = "0.3.0"
 members = [ "cli" ]
 
 [workspace.package]
-version = "0.26.7"
+version = "0.27.0"
 edition = "2024"
 # Tensaku is a fork of Satty; Matthias Gabriel is retained as the
 # original author per the MPL-2.0 (see NOTICE).
@@ -100,5 +100,5 @@ license = "MPL-2.0"
 
 [workspace.dependencies]
 clap = { version = "4.6.1", features = ["derive"] }
-tensaku_cli = { path = "cli", version = "0.26.7" }
+tensaku_cli = { path = "cli", version = "0.27.0" }
 serde = { version = "1.0", features = ["derive"] }


### PR DESCRIPTION



## 🤖 New release

* `tensaku_cli`: 0.26.7 -> 0.27.0 (⚠ API breaking changes)
* `tensaku`: 0.26.7 -> 0.27.0

### ⚠ `tensaku_cli` breaking changes

```text
--- failure constructible_struct_adds_field: externally-constructible struct adds field ---

Description:
A pub struct constructible with a struct literal has a new pub field. Existing struct literals must be updated to include the new field.
        ref: https://doc.rust-lang.org/reference/expressions/struct-expr.html
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.48.0/src/lints/constructible_struct_adds_field.ron

Failed in:
  field CommandLine.capture in /tmp/.tmpFfsSn0/tensaku/cli/src/command_line.rs:67
```

<details><summary><i><b>Changelog</b></i></summary><p>


## `tensaku`

<blockquote>

## [0.27.0](https://github.com/jondkinney/tensaku/compare/v0.26.7...v0.27.0) - 2026-08-21

### Added

- *(pin)* place and stack pins on sway too
- *(pin)* degrade gracefully off Hyprland
- *(pin)* shape the pin like the display
- *(pin,capture)* square stacked pins, click-to-edit, untitled names
- *(capture)* the size pill takes the shot, and the puck matches
- *(capture)* a shutter button beside the restored region's puck
- *(capture)* the cursor says what a restored region will do
- *(capture)* grips and a move puck on a restored region
- *(capture)* adjust a restored region, and hide its measurement
- *(capture)* R restores the last region
- *(capture)* show the selection's pixel size while dragging
- *(scroll-capture)* the same pointer guides as the area capture
- *(capture)* A switches scrolling capture back to a normal one
- *(capture)* crosshair guides before the drag starts
- *(capture)* own the region selection, with window and mode switching
- *(pin)* tooltips, copy confirmations, and drag-out
- *(pin)* copy path saves the shot when it has none
- *(canvas)* the plain wheel walks whichever axis overflows
- *(pin)* pin the finished shot to the desktop
- *(spotlight)* Alt+wheel adjusts the loupe
- *(spotlight)* a magnification slider turns a spotlight into a loupe
- *(text)* an outlined style that reads over anything
- *(blur)* a Secure checkbox states what each mode can undo
- *(shapes)* f toggles fill on any fillable selection
- *(shapes)* a single r / e toggles a selected shape's fill
- *(canvas)* right-click an annotation to restack it
- *(stacking)* text lands above artwork, counters above text
- *(pointer)* plain wheel zooms when the Pointer is armed
- *(prefs)* remove the invert-scrolling preference
- *(canvas)* plain wheel sizes the next annotation
- *(counter)* preview the badge on the canvas, not in the cursor
- *(counter)* the cursor previews the badge it will stamp
- *(counter)* stamp the counter over text instead of grabbing it
- *(shapes)* shape tool buttons show their own fill, and widen the double-tap
- *(shapes)* double-tap a shape's key to toggle its fill, replacing F
- *(selection)* grab large annotations by their border, draw in their interior

### Fixed

- *(pin)* crop the preview to the capture's top, not its middle
- *(pin)* drop the mat and the rounded corner
- *(pin)* float, pin and place through the Lua dispatch API
- *(pin)* tooltips use the app's own, and the drag polls twice a frame
- *(pin)* the drag follows the pointer itself
- *(pin)* drag follows the pointer, and tooltips get out of the way
- *(pin)* slots follow where pins are, and moving one keeps up
- *(capture)* the shutter pill and puck carry their own cursors
- *(pin)* copy works, preview shows the shot, pins stack
- *(capture)* puck back to centre, size and shutter parked beneath it
- *(capture)* size readouts agree with the editor
- *(scroll-capture)* stop spawning hyprctl on every drag event
- *(capture)* hints along the bottom, not across the middle
- *(capture)* don't capture the overlay you just switched away from
- *(scroll-capture)* dim to the same weight as the area capture
- *(capture)* the area overlay wears the scroll capture's pill
- *(capture)* centre the area overlay's hint like the scroll one
- *(text)* the outline is always white
- *(capture)* crosshair pointer while aiming a region
- *(capture)* cache the backdrop; stop toasting the saved text style
- *(capture)* take the picture before the overlay exists
- *(capture)* let the overlay leave the screen before capturing it
- *(capture)* merge the --capture flag into the configuration
- *(pin)* back every pin with a file so the drag carries a path
- *(pin)* drag a thumbnail, not the whole capture
- *(pin)* ask where to save when nothing is configured
- *(pin)* render the pixels the pin needs
- *(text)* Ctrl+Shift+wheel reaches the outlined style
- *(spotlight)* make magnification global, like darkness
- *(spotlight)* render the loupe in the pass that renders spotlights
- *(blur)* stop the secure blur seeding itself from its own glow
- *(blur)* put Secure beside the picker, not inside it
- *(ellipse)* grab the curve, not the box around it
- *(picking)* size the border-grab band in screen pixels
- *(shapes)* apply the r / e fill toggle instead of dropping it
- *(canvas)* stop inverting the compositor's scroll delta
- *(counter)* tighten the badge's lead on the pointer
- *(counter)* system cursor, offset badge
- *(counter)* move the pointer off the number it previews
- *(counter)* the cursor over text matches what the click does
- *(shapes)* keep each shape's fill toggle to that shape
- *(toolbar)* bundle the shape buttons' filled glyphs
- *(selection)* dismiss a selection before drawing inside a large annotation
- *(text)* clicking away from an in-progress text only ends it
- *(text)* grab an existing text box rather than stacking a new one on it
- *(input)* ignore modifiers left over from the launch chord
- *(arrow)* thicken only the tail when zoomed out
- *(canvas)* stop the expanded background showing a line per expansion
- *(omarchy)* opt out of default window opacity, wiring through Lua
- *(selection)* shrink the selection halo with the artwork when zoomed out
- *(canvas)* settle the edge extension away from the boundary
- *(canvas)* extend the image edge per line instead of one flat colour
- *(text)* wrap auto-fit text at the image edge while typing
- *(stitch)* keep a fixed edge's drop shadow out of every seam
- *(stitch)* crop viewport-fixed bands out of the motion search
- *(scroll-capture)* let the page inside a selected region take wheel and keys
- *(scroll-capture)* target the overlay's monitor for capture and pointer warps
- *(render)* tile the spotlight overlay past GL texture limits

### Other

- *(region-capture)* run cargo fmt
- *(pin)* let the compositor move the pin
- *(pin)* lead the pointer by the latency instead of chasing it
- *(pin)* read the pointer off-thread, move on the frame clock
- *(capture)* composite the selection instead of painting it
- Revert "feat(pointer): plain wheel zooms when the Pointer is armed"
- drop the two removed preferences from the README
- *(canvas)* add probes for tile seams and flat-render uniformity
- *(canvas)* grow the raster by re-viewing it, not by copying it
- *(canvas)* add a grow-raster digest harness
- *(canvas)* reuse background textures across an auto-grow
- *(blur)* read back only the blurred region, and stop leaking textures
- *(canvas)* stop copying the raster twice on every re-upload
- *(canvas)* add an env-gated frame profiler
- update star history chart
- update star history chart
- update star history chart
- update star history chart
- *(stitch)* use is_multiple_of in the sparse-doc fixture
- *(stitch)* replay harness takes TENSAKU_STITCH_REPLAY_AXIS
- update star history chart
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).