### PR TITLE
chore: release v0.28.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.28.0](https://github.com/jondkinney/tensaku/compare/v0.27.0...v0.28.0) - 2026-08-21
+
+### Added
+
+- *(scroll-capture)* hands-off pointer — park once, pause on leave
+- *(pin)* close the column gap behind a dragged-away pin
+- *(pin)* right-click names a pin
+- *(pin)* survivors close the gap when a pin closes
+- *(omarchy)* --wire-capture-key binds a key to Tensaku's own capture
+
+### Fixed
+
+- *(scroll-capture)* park the pointer using the output's fractional scale
+- *(pin)* delete the drag snapshot when the pin closes, not on destroy
+- *(capture)* keep overlay chrome from taking the pointer's picks
+
 ## [0.27.0](https://github.com/jondkinney/tensaku/compare/v0.26.7...v0.27.0) - 2026-08-21
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1761,7 +1761,7 @@ checksum = "df7f62577c25e07834649fc3b39fafdc597c0a3527dc1c60129201ccfcbaa50c"
 
 [[package]]
 name = "tensaku"
-version = "0.27.0"
+version = "0.28.0"
 dependencies = [
  "anyhow",
  "chrono",
@@ -1802,7 +1802,7 @@ dependencies = [
 
 [[package]]
 name = "tensaku_cli"
-version = "0.27.0"
+version = "0.28.0"
 dependencies = [
  "clap",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -88,7 +88,7 @@ clap_mangen = "0.3.0"
 members = [ "cli" ]
 
 [workspace.package]
-version = "0.27.0"
+version = "0.28.0"
 edition = "2024"
 # Tensaku is a fork of Satty; Matthias Gabriel is retained as the
 # original author per the MPL-2.0 (see NOTICE).
@@ -100,5 +100,5 @@ license = "MPL-2.0"
 
 [workspace.dependencies]
 clap = { version = "4.6.1", features = ["derive"] }
-tensaku_cli = { path = "cli", version = "0.27.0" }
+tensaku_cli = { path = "cli", version = "0.28.0" }
 serde = { version = "1.0", features = ["derive"] }


### PR DESCRIPTION



## 🤖 New release

* `tensaku_cli`: 0.27.0 -> 0.28.0 (⚠ API breaking changes)
* `tensaku`: 0.27.0 -> 0.28.0

### ⚠ `tensaku_cli` breaking changes

```text
--- failure constructible_struct_adds_field: externally-constructible struct adds field ---

Description:
A pub struct constructible with a struct literal has a new pub field. Existing struct literals must be updated to include the new field.
        ref: https://doc.rust-lang.org/reference/expressions/struct-expr.html
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.48.0/src/lints/constructible_struct_adds_field.ron

Failed in:
  field CommandLine.wire_capture_key in /tmp/.tmpSgsMEV/tensaku/cli/src/command_line.rs:58
```

<details><summary><i><b>Changelog</b></i></summary><p>


## `tensaku`

<blockquote>

## [0.28.0](https://github.com/jondkinney/tensaku/compare/v0.27.0...v0.28.0) - 2026-08-21

### Added

- *(scroll-capture)* hands-off pointer — park once, pause on leave
- *(pin)* close the column gap behind a dragged-away pin
- *(pin)* right-click names a pin
- *(pin)* survivors close the gap when a pin closes
- *(omarchy)* --wire-capture-key binds a key to Tensaku's own capture

### Fixed

- *(scroll-capture)* park the pointer using the output's fractional scale
- *(pin)* delete the drag snapshot when the pin closes, not on destroy
- *(capture)* keep overlay chrome from taking the pointer's picks
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).