### PR TITLE
chore: release v0.29.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,33 +11,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- *(canvas)* expand onto a neutral background with a screenshot shadow
-- open images from launcher or positional CLI input ([#56](https://github.com/jondkinney/tensaku/pull/56))
-- add persistent fixed-canvas preference ([#50](https://github.com/jondkinney/tensaku/pull/50))
+- Add an app-wide **Keep canvas size fixed** preference to clip annotations at the canvas boundary instead of expanding it. Automatic expansion remains the default. (#50)
+- Open a file picker when Tensaku starts without arguments, and accept `tensaku photo.jpg` or `tensaku -` for stdin input. Clipboard annotation is documented with `wl-paste --type image/png | tensaku -`. (#56)
+- Choose an output format in Save As, or convert by changing the filename extension. PNG, JPEG, WebP, AVIF, TIFF, and BMP are available when supported by the installed encoders. Conversion also works with `--output-filename`. (#54)
+
+### Changed
+
+- Expand the canvas onto a neutral background with a subtle shadow around the original screenshot, preserving its crisp edges.
 
 ### Fixed
 
-- *(export)* preserve source formats and support conversion ([#54](https://github.com/jondkinney/tensaku/pull/54))
-- *(render)* prevent canvas seams at fractional zoom
-- *(text)* preserve wrapping and full bounds when moving committed text
-- *(canvas)* use short, stable transitions for expanded edges
-- omit editor selection decorations from exports ([#53](https://github.com/jondkinney/tensaku/pull/53))
-- keep Save As filenames consistent with PNG output ([#54](https://github.com/jondkinney/tensaku/pull/54))
-- parent welcome dialog before presenting it ([#52](https://github.com/jondkinney/tensaku/pull/52))
+- Keep the first-run welcome dialog above its editor so it remains visible and usable. (#52)
+- Exclude selection handles, selection glow, text carets, and other editing decorations from saved images and clipboard copies. (#53)
+- Preserve the input image format in Save As by default and add the correct extension when it is omitted. Unsupported source formats fall back to PNG. (#54)
+- Preserve text wrapping after editing, allow committed text to be dragged beyond the canvas, and include the full text height when expanding the background.
+- Remove seams along the expanded canvas at fractional zoom levels.
+- Keep the editor open after a failed save and preserve the entered filename and format when retrying Save As.
+- Remove routine startup diagnostics and the message for an absent optional CSS overrides file.
 
-### Other
+### Compatibility
 
-- remove routine startup diagnostics
-- satisfy current Clippy pixel-chunk checks
-- update star history chart
-- update star history chart
-- update star history chart
-- update star history chart
-- update star history chart
-- update star history chart
-- update star history chart
-- update star history chart
-- update star history chart
+- `tensaku_cli::CommandLine` adds an `input` field for positional filenames. Rust callers constructing this struct directly must supply the new field.
 
 ## [0.28.0](https://github.com/jondkinney/tensaku/compare/v0.27.0...v0.28.0) - 2026-08-21
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,38 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.29.0](https://github.com/jondkinney/tensaku/compare/v0.28.0...v0.29.0) - 2026-09-05
+
+### Added
+
+- *(canvas)* expand onto a neutral background with a screenshot shadow
+- open images from launcher or positional CLI input ([#56](https://github.com/jondkinney/tensaku/pull/56))
+- add persistent fixed-canvas preference ([#50](https://github.com/jondkinney/tensaku/pull/50))
+
+### Fixed
+
+- *(export)* preserve source formats and support conversion ([#54](https://github.com/jondkinney/tensaku/pull/54))
+- *(render)* prevent canvas seams at fractional zoom
+- *(text)* preserve wrapping and full bounds when moving committed text
+- *(canvas)* use short, stable transitions for expanded edges
+- omit editor selection decorations from exports ([#53](https://github.com/jondkinney/tensaku/pull/53))
+- keep Save As filenames consistent with PNG output ([#54](https://github.com/jondkinney/tensaku/pull/54))
+- parent welcome dialog before presenting it ([#52](https://github.com/jondkinney/tensaku/pull/52))
+
+### Other
+
+- remove routine startup diagnostics
+- satisfy current Clippy pixel-chunk checks
+- update star history chart
+- update star history chart
+- update star history chart
+- update star history chart
+- update star history chart
+- update star history chart
+- update star history chart
+- update star history chart
+- update star history chart
+
 ## [0.28.0](https://github.com/jondkinney/tensaku/compare/v0.27.0...v0.28.0) - 2026-08-21
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1761,7 +1761,7 @@ checksum = "df7f62577c25e07834649fc3b39fafdc597c0a3527dc1c60129201ccfcbaa50c"
 
 [[package]]
 name = "tensaku"
-version = "0.28.0"
+version = "0.29.0"
 dependencies = [
  "anyhow",
  "chrono",
@@ -1802,7 +1802,7 @@ dependencies = [
 
 [[package]]
 name = "tensaku_cli"
-version = "0.28.0"
+version = "0.29.0"
 dependencies = [
  "clap",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -88,7 +88,7 @@ clap_mangen = "0.3.0"
 members = [ "cli" ]
 
 [workspace.package]
-version = "0.28.0"
+version = "0.29.0"
 edition = "2024"
 # Tensaku is a fork of Satty; Matthias Gabriel is retained as the
 # original author per the MPL-2.0 (see NOTICE).
@@ -100,5 +100,5 @@ license = "MPL-2.0"
 
 [workspace.dependencies]
 clap = { version = "4.6.1", features = ["derive"] }
-tensaku_cli = { path = "cli", version = "0.28.0" }
+tensaku_cli = { path = "cli", version = "0.29.0" }
 serde = { version = "1.0", features = ["derive"] }


### PR DESCRIPTION
Release Tensaku and tensaku_cli 0.29.0 with the fixed-canvas preference, file launcher, source-format preservation and conversion, and the annotation rendering fixes.

The workspace version, CLI dependency, and lockfile all move to 0.29.0. The new `CommandLine.input` field is a breaking Rust API change for callers using struct literals; the existing `--filename` command-line option remains supported.

Validation: formatting, Clippy across all targets/features, and 268 tests pass. GUI checks covered source-format saves, explicit format conversion, extension selection, overwrite cancellation, failed-save recovery, and piped JPEG input. The drawing-crash report (#51) remains open.

### Added

- Add an app-wide **Keep canvas size fixed** preference to clip annotations at the canvas boundary instead of expanding it. Automatic expansion remains the default. (#50)
- Open a file picker when Tensaku starts without arguments, and accept `tensaku photo.jpg` or `tensaku -` for stdin input. Clipboard annotation is documented with `wl-paste --type image/png | tensaku -`. (#56)
- Choose an output format in Save As, or convert by changing the filename extension. PNG, JPEG, WebP, AVIF, TIFF, and BMP are available when supported by the installed encoders. Conversion also works with `--output-filename`. (#54)

### Changed

- Expand the canvas onto a neutral background with a subtle shadow around the original screenshot, preserving its crisp edges.

### Fixed

- Keep the first-run welcome dialog above its editor so it remains visible and usable. (#52)
- Exclude selection handles, selection glow, text carets, and other editing decorations from saved images and clipboard copies. (#53)
- Preserve the input image format in Save As by default and add the correct extension when it is omitted. Unsupported source formats fall back to PNG. (#54)
- Preserve text wrapping after editing, allow committed text to be dragged beyond the canvas, and include the full text height when expanding the background.
- Remove seams along the expanded canvas at fractional zoom levels.
- Keep the editor open after a failed save and preserve the entered filename and format when retrying Save As.
- Remove routine startup diagnostics and the message for an absent optional CSS overrides file.

### Compatibility

- `tensaku_cli::CommandLine` adds an `input` field for positional filenames. Rust callers constructing this struct directly must supply the new field.

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/); the release notes have been reviewed.
