### PR TITLE
feat(capture): copy the raw capture to the clipboard as soon as the region is picked

### DIFF
--- a/README.md
+++ b/README.md
@@ -440,7 +440,7 @@ Options:
       --save-after-copy
           After copying the screenshot, save it to a file as well Preferably use the `action_on_copy` option instead
       --auto-copy
-          Automatically copy to clipboard after every annotation change (0.21.0)
+          Automatically copy to clipboard after every annotation change (0.21.0). With --capture, the raw capture is also copied the moment the region is picked
       --actions-on-enter <ACTIONS_ON_ENTER>
           Actions to perform when pressing Enter [possible values: save-to-clipboard, save-to-file, save-to-file-as, copy-filepath-to-clipboard, exit]
       --actions-on-escape <ACTIONS_ON_ESCAPE>

--- a/cli/src/command_line.rs
+++ b/cli/src/command_line.rs
@@ -145,7 +145,7 @@ pub struct CommandLine {
     #[arg(long)]
     pub save_after_copy: bool,
 
-    /// Automatically copy to clipboard after every annotation change (0.21.0)
+    /// Automatically copy to clipboard after every annotation change (0.21.0). With --capture, the raw capture is also copied the moment the region is picked
     #[arg(long)]
     pub auto_copy: bool,
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,8 +1,8 @@
 //! Tensaku — a modern screenshot annotation tool, forked from Satty.
 
 use configuration::{APP_CONFIG, Configuration};
-use std::io::Read;
-use std::process::exit;
+use std::io::{Read, Write};
+use std::process::{Command, Stdio, exit};
 use std::sync::LazyLock;
 use std::{fs, ptr};
 use std::{io, time::Duration};
@@ -2344,6 +2344,9 @@ fn run_capture_flow(mut scrolling: bool) -> Result<()> {
                     continue;
                 }
                 scroll_capture::ScrollRun::Captured(outcome) => {
+                    if APP_CONFIG.read().auto_copy() {
+                        copy_capture_to_clipboard(&outcome.image);
+                    }
                     load_gl()?;
                     return start_gui_with_toast(outcome.image, outcome.warning);
                 }
@@ -2373,8 +2376,53 @@ fn run_capture_flow(mut scrolling: bool) -> Result<()> {
                 continue;
             }
         };
+        if APP_CONFIG.read().auto_copy() {
+            copy_capture_to_clipboard(&image);
+        }
         load_gl()?;
         return start_gui_with_toast(image, None);
+    }
+}
+
+/// Put the freshly taken capture on the clipboard before the editor opens.
+///
+/// Not every screenshot gets annotated, so the clipboard should already
+/// hold the raw capture the moment the region is picked; `auto-copy`
+/// re-copies after every annotation change, so later edits simply
+/// overwrite it. The GTK clipboard is not an option here — no display
+/// has been opened yet — hence the same external helper
+/// `save_bytes_to_external_process` uses.
+fn copy_capture_to_clipboard(image: &Pixbuf) {
+    let command = APP_CONFIG
+        .read()
+        .copy_command()
+        .cloned()
+        .unwrap_or_else(|| "wl-copy --type image/png".to_string());
+
+    let copy = || -> Result<()> {
+        let data = image.save_to_bufferv("png", &[])?;
+        let mut child = Command::new("sh")
+            .arg("-c")
+            .arg(&command)
+            .stdin(Stdio::piped())
+            .stdout(Stdio::null())
+            .spawn()?;
+        let mut stdin = child
+            .stdin
+            .take()
+            .context("clipboard command provided no stdin")?;
+        stdin.write_all(&data)?;
+        drop(stdin);
+        if !child.wait()?.success() {
+            return Err(anyhow!("clipboard command '{command}' failed"));
+        }
+        Ok(())
+    };
+
+    // Never fatal: a missing clipboard helper must not cost the user the
+    // screenshot they just took.
+    if let Err(e) = copy() {
+        eprintln!("Could not copy the capture to the clipboard: {e}");
     }
 }
 


### PR DESCRIPTION
## What

With `auto-copy = true`, `tensaku --capture` (and `--scroll-capture`) now copies the freshly taken screenshot to the clipboard **before** the annotation editor opens. Edits keep overwriting the clipboard through the existing auto-copy behaviour. With `auto-copy` off, nothing changes.

## Why

Not every screenshot needs annotating. Today the region picker is the best part of the workflow, but after picking a region you still have to press Enter / click copy in the editor before the shot is usable elsewhere. With this change the clipboard already holds the raw capture the moment the region is chosen, and the editor is there only if you want it.

## How

- New `copy_capture_to_clipboard()` in `src/main.rs`, called from both capture paths (region/fullscreen and scroll) right before `load_gl()` / `start_gui_with_toast()`, guarded by `APP_CONFIG.read().auto_copy()`.
- No GTK clipboard (no display yet): the PNG bytes go to the configured `copy-command` via `sh -c` with piped stdin, mirroring `SketchBoard::save_bytes_to_external_process`; fallback `wl-copy --type image/png`.
- A failed copy prints one line to stderr and never blocks the capture.
- `--auto-copy` help text updated; README regenerated with `make update-readme`. `cargo fmt` and `cargo clippy` clean.

Tested on Hyprland 0.56 (Arch, tensaku 0.29.0): region pick → clipboard immediately holds the capture, editor opens as before; annotation changes keep updating the clipboard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
