### PR TITLE
fix(input): ignore Caps Lock when matching keyboard shortcuts

### DIFF
--- a/src/scroll_capture/mod.rs
+++ b/src/scroll_capture/mod.rs
@@ -1300,7 +1300,7 @@ fn build_overlay(
             // the area overlay's S. Handing back beats making someone
             // close this and press a different keybind.
             if matches!(key, gtk::gdk::Key::a | gtk::gdk::Key::A)
-                && modifier.is_empty()
+                && (modifier - gtk::gdk::ModifierType::LOCK_MASK).is_empty()
                 && matches!(state_keys.borrow().phase, Phase::AwaitingDrag)
             {
                 switch_to_area.set(true);

--- a/src/sketch_board.rs
+++ b/src/sketch_board.rs
@@ -6815,7 +6815,13 @@ impl KeyEventMsg {
         Self {
             key,
             code,
-            modifier,
+            // Caps Lock rides along as LOCK_MASK on top of whatever is
+            // really held, and the shortcut chain compares the modifier
+            // set exactly (`ke.modifier == CONTROL_MASK`). So with Caps
+            // Lock on, every chord — Ctrl+C, Ctrl+V, undo, save — missed
+            // its arm and did nothing at all. A lock state says nothing
+            // about which modifiers are down, so it is not part of a chord.
+            modifier: modifier - ModifierType::LOCK_MASK,
         }
     }
 
@@ -7037,5 +7043,40 @@ mod launch_chord_tests {
         // ...and a mix keeps the harmless half.
         let mixed = other | ModifierType::SHIFT_MASK;
         assert_eq!(trusted_modifiers(mixed, false), other);
+    }
+}
+
+#[cfg(test)]
+mod caps_lock_tests {
+    use super::{Key, KeyEventMsg, ModifierType};
+
+    /// Caps Lock is reported as LOCK_MASK alongside the real chord.
+    /// Every shortcut compares the modifier set exactly, so the bit has
+    /// to be gone by the time a KeyEventMsg exists — otherwise Ctrl+C
+    /// and every other chord is dead while Caps Lock is on.
+    #[test]
+    fn caps_lock_is_not_part_of_a_chord() {
+        let event = KeyEventMsg::new(
+            Key::C,
+            54,
+            ModifierType::CONTROL_MASK | ModifierType::LOCK_MASK,
+        );
+        assert_eq!(event.modifier, ModifierType::CONTROL_MASK);
+    }
+
+    /// And a key pressed with nothing but Caps Lock on is an unmodified
+    /// key, which is what the single-letter tool shortcuts test for.
+    #[test]
+    fn caps_lock_alone_is_no_modifier() {
+        let event = KeyEventMsg::new(Key::A, 38, ModifierType::LOCK_MASK);
+        assert!(event.modifier.is_empty());
+    }
+
+    /// Nothing else is touched.
+    #[test]
+    fn real_modifiers_survive() {
+        let held = ModifierType::CONTROL_MASK | ModifierType::SHIFT_MASK;
+        let event = KeyEventMsg::new(Key::z, 52, held | ModifierType::LOCK_MASK);
+        assert_eq!(event.modifier, held);
     }
 }


### PR DESCRIPTION
## What

Keyboard shortcuts do nothing while Caps Lock is on — Ctrl+C, Ctrl+V, Ctrl+Z, Ctrl+S, Ctrl+A, all of them. Fixes #61.

## Why

GTK reports Caps Lock as `ModifierType::LOCK_MASK` in the key event's modifier state, on top of what is really held. The shortcut chain compares the modifier set exactly (`ke.modifier == ModifierType::CONTROL_MASK`, ~28 sites in `sketch_board.rs`, `tools/text.rs`, `tools/pointer.rs`), so the extra bit makes every chord miss. Measured with a minimal GTK4 `EventControllerKey` on Hyprland/Wayland:

```
caps off:  keyval=c  code=54  state=GDK_CONTROL_MASK                  (4)
caps on:   keyval=C  code=54  state=GDK_LOCK_MASK | GDK_CONTROL_MASK  (6)
```

`is_one_of` already copes with the uppercase keysym, so the modifier set is the whole problem.

## How

A lock state says nothing about which modifiers are down, so it is dropped where key events are built:

- `KeyEventMsg::new` subtracts `LOCK_MASK`. That is the single funnel both the press and the release handler go through, so every comparison downstream — including `crop.rs`'s `other_mods.is_empty()` arrow-key gate — is fixed at once, with no change to the comparisons themselves.
- The scroll-capture overlay's plain `A` gate has its own `modifier.is_empty()` check outside that funnel; it now ignores `LOCK_MASK` too.

Mouse events are left alone: nothing on that path compares the modifier set exactly, `trusted_modifiers` keeps its current contract, and its tests still assert that lock state passes through untouched.

## Tests

Three unit tests in a new `caps_lock_tests` module: Ctrl+Caps keeps only Ctrl, Caps alone is no modifier at all, and other modifiers survive. `cargo fmt`, `cargo clippy --all-targets` and `cargo test` are clean.

Verified by hand on Hyprland 0.56.2 / gtk4 4.22.4: with Caps Lock on, copy, paste, undo and save all work again.
